### PR TITLE
Revert "Bugfix: native build was wrongly picked up by default"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,8 @@ compile_error!("One of the features `pio` or `native` must be selected.");
 // specifies it, this overrides the `pio` feature for all other dependencies too.
 // See https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features.
 #[cfg(any(feature = "pio", feature = "native"))]
-#[cfg_attr(feature = "pio", path = "build_pio.rs")]
-#[cfg_attr(all(feature = "native", not(feature = "pio")), path = "build_native.rs")]
+#[cfg_attr(feature = "native", path = "build_native.rs")]
+#[cfg_attr(all(feature = "pio", not(feature = "native")), path = "build_pio.rs")]
 mod build_impl;
 
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
This reverts commit 24305252d8c50b9123453c2919ccd183bd370b5d partially.
This commit caused the `native` feature to become unusable.

Note: 
Setting the feature `native` in any dependant crate causes the native build to be used for the whole compilation.