### PR TITLE
Various fixes for the native build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-idf-sys"
-version = "0.19.6"
+version = "0.20.0"
 authors = ["Alexey Arbuzov <aarbuzov@termt.com>", "sapir <yasapir@gmail.com>", "Ivan Markov <ivan.markov@gmail.com>"]
 edition = "2018"
 categories = ["embedded", "hardware-support"]
@@ -31,6 +31,7 @@ embedded-svc = "0.8.3"
 paste = "1"
 
 [build-dependencies]
-embuild = "0.23.5"
-anyhow = { version = "1" }
+embuild = "0.24"
+anyhow = "1"
 strum = { version = "0.21", optional = true, features = ["derive"] }
+regex = "1.5"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,12 @@
 #[cfg(not(any(feature = "pio", feature = "native")))]
 compile_error!("One of the features `pio` or `native` must be selected.");
 
+use anyhow::*;
+use regex::{self};
+use std::{env, error, fs, iter::once, path::{Path, PathBuf}, str::FromStr};
+
+use embuild::{bindgen, build, cargo, kconfig, path_buf, utils::OsStrExt};
+
 // Note that the feature `native` must come before `pio`. These features are really
 // mutually exclusive but that would require that all dependencies specify the same
 // feature so instead we prefer the `native` feature over `pio` so that if one package
@@ -11,6 +17,148 @@ compile_error!("One of the features `pio` or `native` must be selected.");
 #[cfg_attr(all(feature = "pio", not(feature = "native")), path = "build_pio.rs")]
 mod build_impl;
 
+pub(crate) const STABLE_PATCHES: &[&str] = &[
+    "patches/missing_xtensa_atomics_fix.diff",
+    "patches/pthread_destructor_fix.diff",
+    "patches/ping_setsockopt_fix.diff",
+];
+
+#[allow(unused)]
+pub(crate) const MASTER_PATCHES: &[&str] = &[
+    "patches/master_missing_xtensa_atomics_fix.diff",
+];
+
+pub(crate) struct EspIdfBuildOutput<I>
+where
+    I: Iterator<Item = (String, kconfig::Value)>,
+{
+    pub(crate) cincl_args: build::CInclArgs,
+    pub(crate) link_args: Option<build::LinkArgs>,
+    pub(crate) kconfig_args: I,
+    pub(crate) bindgen: bindgen::Factory,
+}
+
+struct EspIdfVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl EspIdfVersion {
+    fn parse(bindings_file: impl AsRef<Path>) -> Result<Self> {
+        let bindings_content = fs::read_to_string(bindings_file.as_ref())?;
+
+        Ok(Self {
+            major: Self::grab_const(&bindings_content, "ESP_IDF_VERSION_MAJOR", "u32")?,
+            minor: Self::grab_const(&bindings_content, "ESP_IDF_VERSION_MINOR", "u32")?,
+            patch: Self::grab_const(bindings_content, "ESP_IDF_VERSION_PATCH", "u32")?,
+        })
+    }
+
+    fn get_cfg(&self) -> impl Iterator<Item = String> {
+        once(format!(
+            "esp_idf_full_version=\"{}.{}.{}\"",
+            self.major, self.minor, self.patch
+        ))
+        .chain(once(format!(
+            "esp_idf_version=\"{}.{}\"",
+            self.major, self.minor
+        )))
+        .chain(once(format!("esp_idf_major_version=\"{}\"", self.major)))
+        .chain(once(format!("esp_idf_minor_version=\"{}\"", self.minor)))
+        .chain(once(format!("esp_idf_patch_version=\"{}\"", self.patch)))
+    }
+
+    fn grab_const<T>(text: impl AsRef<str>, const_name: impl AsRef<str>, const_type: impl AsRef<str>) -> Result<T> where T: FromStr, T::Err: error::Error + Send + Sync + 'static {
+        let const_name = const_name.as_ref();
+
+        let value = regex::Regex::new(&format!(r"\s+const\s+{}\s*:\s*{}\s*=\s*(\S+)\s*;", const_name, const_type.as_ref()))?
+            .captures(text.as_ref())
+            .ok_or_else(|| anyhow!("Failed to capture constant {}", const_name))?
+            .get(1)
+            .ok_or_else(|| anyhow!("Failed to capture the value of constant {}", const_name))?
+            .as_str()
+            .parse::<T>()?;
+
+        Ok(value)
+    }
+}
+
 fn main() -> anyhow::Result<()> {
-    build_impl::main()
+    let build_output = build_impl::main()?;
+
+    // We need to restrict the kconfig parameters which are turned into rustc cfg items
+    // because otherwise we would be hitting rustc command line restrictions on Windows
+    //
+    // For now, we take all tristate parameters which are set to true, as well as a few
+    // selected string ones, as per below
+    //
+    // This might change in future
+    let kconfig_str_allow = regex::Regex::new(r"IDF_TARGET")?;
+
+    let cfg_args = build::CfgArgs {
+        args: build_output
+            .kconfig_args
+            .filter(|(key, value)| {
+                matches!(value, kconfig::Value::Tristate(kconfig::Tristate::True)) || kconfig_str_allow.is_match(key)
+            })
+            .filter_map(|(key, value)| value.to_rustc_cfg("esp_idf", key))
+            .collect(),
+    };
+
+    let mcu = cfg_args
+        .get("esp_idf_idf_target")
+        .ok_or_else(|| anyhow!("Failed to get IDF_TARGET from kconfig. cfgs:\n{:?}", cfg_args.args))?;
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+
+    let header_file = path_buf![
+        manifest_dir,
+        "src",
+        "include",
+        if mcu == "esp8266" {
+            "esp-8266-rtos-sdk"
+        } else {
+            "esp-idf"
+        },
+        "bindings.h"
+    ];
+
+    cargo::track_file(&header_file);
+
+    let bindings_file = bindgen::run(
+        build_output
+            .bindgen
+            .builder()?
+            .ctypes_prefix("c_types")
+            .header(header_file.try_to_str()?)
+            .blacklist_function("strtold")
+            .blacklist_function("_strtold_r")
+            .clang_args(if mcu == "esp32c3" {
+                vec!["-target", "riscv32"]
+            } else {
+                vec![]
+            }),
+    )?;
+
+    let cfg_args = build::CfgArgs {
+        args: cfg_args
+            .args
+            .into_iter()
+            .chain(EspIdfVersion::parse(bindings_file)?.get_cfg())
+            .chain(once(mcu))
+            .collect(),
+    };
+
+    cfg_args.propagate();
+    cfg_args.output();
+
+    // In case other SYS crates need to have access to the ESP-IDF C headers
+    build_output.cincl_args.propagate();
+
+    if let Some(link_args) = build_output.link_args {
+        link_args.propagate();
+    }
+
+    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -158,8 +158,10 @@ fn main() -> anyhow::Result<()> {
             .clang_args(vec![
                 "-target",
                 if mcu == "esp32c3" {
+                    // Necessary to pass explicitly, because of https://github.com/rust-lang/rust-bindgen/issues/1555
                     "riscv32"
                 } else {
+                    // We don't really have a similar issue with Xtensa, but we pass it explicitly as well just in case
                     "xtensa"
                 },
             ]),

--- a/build_native.rs
+++ b/build_native.rs
@@ -17,6 +17,10 @@ use embuild::utils::{OsStrExt, PathExt};
 use embuild::{bindgen, build, cargo, cmake, cmd, cmd_output, git, kconfig, path_buf};
 use strum::{Display, EnumString};
 
+use super::EspIdfBuildOutput;
+use super::MASTER_PATCHES;
+use super::STABLE_PATCHES;
+
 const SDK_DIR_VAR: &str = "SDK_DIR";
 const ESP_IDF_VERSION_VAR: &str = "ESP_IDF_VERSION";
 const ESP_IDF_REPOSITORY_VAR: &str = "ESP_IDF_REPOSITORY";
@@ -28,16 +32,6 @@ const MCU_VAR: &str = "MCU";
 const DEFAULT_SDK_DIR: &str = ".espressif";
 const DEFAULT_ESP_IDF_REPOSITORY: &str = "https://github.com/espressif/esp-idf.git";
 const DEFAULT_ESP_IDF_VERSION: &str = "v4.3";
-
-const STABLE_PATCHES: &[&str] = &[
-    "patches/missing_xtensa_atomics_fix.diff",
-    "patches/pthread_destructor_fix.diff",
-    "patches/ping_setsockopt_fix.diff",
-];
-const MASTER_PATCHES: &[&str] = &[
-    "patches/master_missing_xtensa_atomics_fix.diff",
-    "patches/ping_setsockopt_fix.diff",
-];
 
 fn esp_idf_version() -> git::Ref {
     let version = env::var(ESP_IDF_VERSION_VAR).unwrap_or(DEFAULT_ESP_IDF_VERSION.to_owned());
@@ -64,7 +58,9 @@ fn esp_idf_version() -> git::Ref {
     }
 }
 
-pub fn main() -> Result<()> {
+pub(crate) fn main() -> Result<EspIdfBuildOutput<impl Iterator<Item = (String, kconfig::Value)>>> {
+    // TODO: Implement support for CMake-first builds in a similar way as to how cargo-pio supports PIO-first builds
+
     let out_dir = path_buf![env::var("OUT_DIR")?];
     let target = env::var("TARGET")?;
     let workspace_dir = out_dir.pop_times(6);
@@ -188,7 +184,7 @@ pub fn main() -> Result<()> {
     }
 
     // Get the paths to the tools.
-    let mut bin_paths: Vec<_> = cmd_output!(python, &idf_tools_py, "--idf-path", &esp_idf_dir, "--quiet", "export", "--format=key-value"; 
+    let mut bin_paths: Vec<_> = cmd_output!(python, &idf_tools_py, "--idf-path", &esp_idf_dir, "--quiet", "export", "--format=key-value";
                                             ignore_exitcode, env=("IDF_TOOLS_PATH", &sdk_dir))
                             .lines()
                             .find(|s| s.trim_start().starts_with("PATH="))
@@ -316,45 +312,28 @@ pub fn main() -> Result<()> {
         })
         .context("Could not determine the compiler from cmake")?;
 
-    let header_file = path_buf![&manifest_dir, "src", "include", "esp-idf", "bindings.h"];
-
-    bindgen::run(
-        bindgen::Factory::from_cmake(&target.compile_groups[0])?
-            .with_linker(&compiler)
-            .builder()?
-            .ctypes_prefix("c_types")
-            .header(header_file.try_to_str()?)
-            .blacklist_function("strtold")
-            .blacklist_function("_strtold_r")
-            .clang_args(["-target", chip.clang_target()]),
-    )?;
-
-    // Output the exact ESP32 MCU, so that we and crates depending directly on us can branch using e.g. #[cfg(esp32xxx)]
-    cargo::set_rustc_cfg(chip, "");
-    cargo::set_metadata("MCU", chip);
-
-    build::LinkArgsBuilder::try_from(&target.link.unwrap())?
-        .linker(&compiler)
-        .working_directory(&cmake_build_dir)
-        .force_ldproxy(true)
-        .build()?
-        .propagate();
-
-    // In case other SYS crates need to have access to the ESP-IDF C headers
-    build::CInclArgs::try_from(&target.compile_groups[0])?.propagate();
-
     let sdkconfig_json = path_buf![&cmake_build_dir, "config", "sdkconfig.json"];
-    let cfgs = kconfig::CfgArgs::try_from_json(&sdkconfig_json)
-        .with_context(|| anyhow!("Failed to read '{:?}'", sdkconfig_json))?;
-    cfgs.propagate("ESP_IDF");
-    cfgs.output("ESP_IDF");
 
-    Ok(())
+    let build_output = EspIdfBuildOutput {
+        cincl_args: build::CInclArgs::try_from(&target.compile_groups[0])?,
+        link_args: Some(
+            build::LinkArgsBuilder::try_from(&target.link.unwrap())?
+                .linker(&compiler)
+                .working_directory(&cmake_build_dir)
+                .force_ldproxy(true)
+                .build()?,
+        ),
+        bindgen: bindgen::Factory::from_cmake(&target.compile_groups[0])?.with_linker(&compiler),
+        kconfig_args: kconfig::try_from_json_file(sdkconfig_json.clone())
+            .with_context(|| anyhow!("Failed to read '{:?}'", sdkconfig_json))?,
+    };
+
+    Ok(build_output)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Display, EnumString)]
 #[repr(u32)]
-pub enum Chip {
+enum Chip {
     /// Xtensa LX7 based dual core
     #[strum(serialize = "esp32")]
     ESP32 = 0,
@@ -370,7 +349,7 @@ pub enum Chip {
 }
 
 impl Chip {
-    pub fn detect(rust_target_triple: &str) -> Result<Chip> {
+    fn detect(rust_target_triple: &str) -> Result<Chip> {
         if rust_target_triple.starts_with("xtensa-esp") {
             if rust_target_triple.contains("esp32s3") {
                 return Ok(Chip::ESP32S3);
@@ -386,7 +365,7 @@ impl Chip {
     }
 
     /// The name of the gcc toolchain (to compile the `esp-idf`) for `idf_tools.py`.
-    pub fn gcc_toolchain(self) -> &'static str {
+    fn gcc_toolchain(self) -> &'static str {
         match self {
             Self::ESP32 => "xtensa-esp32-elf",
             Self::ESP32S2 => "xtensa-esp32s2-elf",
@@ -397,7 +376,7 @@ impl Chip {
 
     /// The name of the gcc toolchain for the ultra low-power co-processor for
     /// `idf_tools.py`.
-    pub fn ulp_gcc_toolchain(self) -> Option<&'static str> {
+    fn ulp_gcc_toolchain(self) -> Option<&'static str> {
         match self {
             Self::ESP32 => Some("esp32ulp-elf"),
             Self::ESP32S2 => Some("esp32s2ulp-elf"),
@@ -405,14 +384,7 @@ impl Chip {
         }
     }
 
-    pub fn cmake_toolchain_file(self) -> String {
+    fn cmake_toolchain_file(self) -> String {
         format!("toolchain-{}.cmake", self)
-    }
-
-    pub fn clang_target(self) -> &'static str {
-        match self {
-            Self::ESP32 | Self::ESP32S2 | Self::ESP32S3 => "xtensa",
-            Self::ESP32C3 => "riscv32",
-        }
     }
 }

--- a/build_pio.rs
+++ b/build_pio.rs
@@ -71,7 +71,13 @@ pub(crate) fn main() -> Result<EspIdfBuildOutput<impl Iterator<Item = (String, k
         bindgen: bindgen::Factory::from_scons_vars(&pio_scons_vars)?,
         kconfig_args: kconfig::try_from_config_file(sdkconfig.clone())
             .with_context(|| anyhow!("Failed to read '{:?}'", sdkconfig))?
-            .map(|(key, value)| if key.starts_with("CONFIG_") { (key["CONFIG_".len()..].into(), value) } else { (key, value) }),
+            .map(|(key, value)| {
+                if key.starts_with("CONFIG_") {
+                    (key["CONFIG_".len()..].into(), value)
+                } else {
+                    (key, value)
+                }
+            }),
     };
 
     Ok(build_output)

--- a/build_pio.rs
+++ b/build_pio.rs
@@ -5,134 +5,74 @@ use std::{env, path::PathBuf};
 
 use anyhow::*;
 
-use embuild::bindgen;
 use embuild::build;
-use embuild::cargo;
 use embuild::kconfig;
 use embuild::pio;
 use embuild::pio::project;
+use embuild::{bindgen, path_buf};
 
-pub fn main() -> Result<()> {
-    let pio_scons_vars = if let Some(pio_scons_vars) = project::SconsVariables::from_piofirst() {
-        println!("cargo:info=PIO->Cargo build detected: generating bindings only");
+use super::EspIdfBuildOutput;
 
-        pio_scons_vars
-    } else {
-        let pio = pio::Pio::install_default()?;
+pub(crate) fn main() -> Result<EspIdfBuildOutput<impl Iterator<Item = (String, kconfig::Value)>>> {
+    let (pio_scons_vars, link_args) =
+        if let Some(pio_scons_vars) = project::SconsVariables::from_piofirst() {
+            println!("cargo:info=PIO->Cargo build detected: generating bindings only");
 
-        let resolution = pio::Resolver::new(pio.clone())
-            .params(pio::ResolutionParams {
-                platform: Some("espressif32".into()),
-                frameworks: vec!["espidf".into()],
-                target: Some(env::var("TARGET")?),
-                ..Default::default()
-            })
-            .resolve(true)?;
+            (pio_scons_vars, None)
+        } else {
+            let pio = pio::Pio::install_default()?;
 
-        let mut builder =
-            project::Builder::new(PathBuf::from(env::var("OUT_DIR")?).join("esp-idf"));
+            let resolution = pio::Resolver::new(pio.clone())
+                .params(pio::ResolutionParams {
+                    platform: Some("espressif32".into()),
+                    frameworks: vec!["espidf".into()],
+                    target: Some(env::var("TARGET")?),
+                    ..Default::default()
+                })
+                .resolve(true)?;
 
-        builder
-            .enable_scons_dump()
-            .enable_c_entry_points()
-            .options(build::env_options_iter("ESP_IDF_SYS_PIO_CONF")?)
-            .files(build::tracked_globs_iter(
-                PathBuf::from("."),
-                &["patches/**"],
-            )?)
-            .files(build::tracked_env_globs_iter("ESP_IDF_SYS_GLOB")?);
+            let mut builder =
+                project::Builder::new(PathBuf::from(env::var("OUT_DIR")?).join("esp-idf"));
 
-        #[cfg(feature = "espidf_master")]
-        builder
-            .platform_package(
-                "framework-espidf",
-                "https://github.com/ivmarkov/esp-idf.git#master",
-            )
-            .platform_package_patch(
-                PathBuf::from("patches").join("master_missing_xtensa_atomics_fix.diff"),
-                PathBuf::from("framework-espidf"),
-            )
-            .platform_package_patch(
-                PathBuf::from("patches").join("ping_setsockopt_fix.diff"),
-                PathBuf::from("framework-espidf"),
-            );
+            builder
+                .enable_scons_dump()
+                .enable_c_entry_points()
+                .options(build::env_options_iter("ESP_IDF_SYS_PIO_CONF")?)
+                .files(build::tracked_globs_iter(path_buf!["."], &["patches/**"])?)
+                .files(build::tracked_env_globs_iter("ESP_IDF_SYS_GLOB")?);
 
-        #[cfg(feature = "espidf_master")]
-        env::set_var("IDF_MAINTAINER", "1");
+            for patch in super::STABLE_PATCHES {
+                builder.platform_package_patch(PathBuf::from(patch), path_buf!["framework-espidf"]);
+            }
 
-        #[cfg(not(feature = "espidf_master"))]
-        builder
-            .platform_package_patch(
-                PathBuf::from("patches").join("pthread_destructor_fix.diff"),
-                PathBuf::from("framework-espidf"),
-            )
-            .platform_package_patch(
-                PathBuf::from("patches").join("ping_setsockopt_fix.diff"),
-                PathBuf::from("framework-espidf"),
-            )
-            .platform_package_patch(
-                PathBuf::from("patches").join("missing_xtensa_atomics_fix.diff"),
-                PathBuf::from("framework-espidf"),
-            );
+            let project_path = builder.generate(&resolution)?;
 
-        let project_path = builder.generate(&resolution)?;
+            pio.build(&project_path, env::var("PROFILE")? == "release")?;
 
-        pio.build(&project_path, env::var("PROFILE")? == "release")?;
+            let pio_scons_vars = project::SconsVariables::from_dump(&project_path)?;
 
-        let pio_scons_vars = project::SconsVariables::from_dump(&project_path)?;
+            let link_args = build::LinkArgsBuilder::try_from(&pio_scons_vars)?.build()?;
 
-        build::LinkArgsBuilder::try_from(&pio_scons_vars)?
-            .build()?
-            .propagate();
+            (pio_scons_vars, Some(link_args))
+        };
 
-        pio_scons_vars
+    let sdkconfig = path_buf![
+        &pio_scons_vars.project_dir,
+        if pio_scons_vars.release_build {
+            "sdkconfig.release"
+        } else {
+            "sdkconfig.debug"
+        }
+    ];
+
+    let build_output = EspIdfBuildOutput {
+        cincl_args: build::CInclArgs::try_from(&pio_scons_vars)?,
+        link_args,
+        bindgen: bindgen::Factory::from_scons_vars(&pio_scons_vars)?,
+        kconfig_args: kconfig::try_from_config_file(sdkconfig.clone())
+            .with_context(|| anyhow!("Failed to read '{:?}'", sdkconfig))?
+            .map(|(key, value)| if key.starts_with("CONFIG_") { (key["CONFIG_".len()..].into(), value) } else { (key, value) }),
     };
 
-    // In case other SYS crates need to have access to the ESP-IDF C headers
-    build::CInclArgs::try_from(&pio_scons_vars)?.propagate();
-
-    let cfg_args = kconfig::CfgArgs::try_from(
-        pio_scons_vars
-            .project_dir
-            .join(if pio_scons_vars.release_build {
-                "sdkconfig.release"
-            } else {
-                "sdkconfig.debug"
-            })
-            .as_path(),
-    )?;
-
-    cfg_args.propagate("ESP_IDF");
-    cfg_args.output("ESP_IDF");
-
-    let mcu = pio_scons_vars.mcu.as_str();
-
-    // Output the exact ESP32 MCU, so that we and crates depending directly on us can branch using e.g. #[cfg(esp32xxx)]
-    cargo::set_rustc_cfg(mcu, "");
-    cargo::set_metadata("MCU", mcu);
-
-    let header = PathBuf::from("src")
-        .join("include")
-        .join(if mcu == "esp8266" {
-            "esp-8266-rtos-sdk"
-        } else {
-            "esp-idf"
-        })
-        .join("bindings.h");
-
-    cargo::track_file(&header);
-
-    bindgen::run(
-        bindgen::Factory::from_scons_vars(&pio_scons_vars)?
-            .builder()?
-            .ctypes_prefix("c_types")
-            .header(header.to_string_lossy())
-            .blacklist_function("strtold")
-            .blacklist_function("_strtold_r")
-            .clang_args(if mcu == "esp32c3" {
-                vec!["-target", "riscv32"]
-            } else {
-                vec![]
-            }),
-    )
+    Ok(build_output)
 }

--- a/patches/master_missing_xtensa_atomics_fix.diff
+++ b/patches/master_missing_xtensa_atomics_fix.diff
@@ -1,12 +1,12 @@
 diff --git a/components/newlib/stdatomic.c b/components/newlib/stdatomic.c
-index 993fcd1ac..fe5e2e845 100644
+index bbd2d17e80..bbe1a0325a 100644
 --- a/components/newlib/stdatomic.c
 +++ b/components/newlib/stdatomic.c
-@@ -186,6 +186,22 @@ static portMUX_TYPE s_atomic_lock = portMUX_INITIALIZER_UNLOCKED;
-     return ret;                                                                  \
- }
- 
-+#define SYNC_LOCK_TEST_AND_SET(n, type) type  __sync_lock_test_and_set_ ## n  (type *ptr, type val, ...) \
+@@ -208,6 +208,23 @@ CLANG_DECLARE_ALIAS( __sync_bool_compare_and_swap_ ## n )
+ }                                                                                \
+ CLANG_DECLARE_ALIAS( __sync_val_compare_and_swap_ ## n )
+
++#define SYNC_LOCK_TEST_AND_SET(n, type) type  CLANG_ATOMIC_SUFFIX(__sync_lock_test_and_set_ ## n)  (type *ptr, type val, ...) \
 +{                                                                                \
 +    unsigned state = _ATOMIC_ENTER_CRITICAL();                                   \
 +    type ret = *ptr;                                                             \
@@ -14,21 +14,22 @@ index 993fcd1ac..fe5e2e845 100644
 +    _ATOMIC_EXIT_CRITICAL(state);                                                \
 +    return ret;                                                                  \
 +}
++CLANG_DECLARE_ALIAS( __sync_lock_test_and_set_ ## n )
 +
-+#define SYNC_LOCK_RELEASE(n, type) void  __sync_lock_release_ ## n  (type *ptr, ...) \
++#define SYNC_LOCK_RELEASE(n, type) void  CLANG_ATOMIC_SUFFIX(__sync_lock_release_ ## n)  (type *ptr, ...) \
 +{                                                                                \
 +    unsigned state = _ATOMIC_ENTER_CRITICAL();                                   \
 +    *ptr = 0;                                                                    \
 +    _ATOMIC_EXIT_CRITICAL(state);                                                \
 +}
-+
++CLANG_DECLARE_ALIAS( __sync_lock_release_ ## n )
+
  #if !HAS_ATOMICS_32
- 
- ATOMIC_EXCHANGE(1, uint8_t)
-@@ -244,6 +260,14 @@ SYNC_VAL_CMP_EXCHANGE(1, uint8_t)
+
+@@ -267,6 +284,14 @@ SYNC_VAL_CMP_EXCHANGE(1, uint8_t)
  SYNC_VAL_CMP_EXCHANGE(2, uint16_t)
  SYNC_VAL_CMP_EXCHANGE(4, uint32_t)
- 
+
 +SYNC_LOCK_TEST_AND_SET(1, uint8_t)
 +SYNC_LOCK_TEST_AND_SET(2, uint16_t)
 +SYNC_LOCK_TEST_AND_SET(4, uint32_t)
@@ -38,12 +39,12 @@ index 993fcd1ac..fe5e2e845 100644
 +SYNC_LOCK_RELEASE(4, uint32_t)
 +
  #endif // !HAS_ATOMICS_32
- 
+
  #if !HAS_ATOMICS_64
-@@ -280,4 +304,8 @@ SYNC_BOOL_CMP_EXCHANGE(8, uint64_t)
- 
+@@ -303,4 +328,8 @@ SYNC_BOOL_CMP_EXCHANGE(8, uint64_t)
+
  SYNC_VAL_CMP_EXCHANGE(8, uint64_t)
- 
+
 +SYNC_LOCK_TEST_AND_SET(8, uint64_t)
 +
 +SYNC_LOCK_RELEASE(8, uint64_t)

--- a/resources/cmake_project/CMakeLists.txt
+++ b/resources/cmake_project/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(SDKCONFIG $ENV{SDKCONFIG})
-set(SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS})
-
 include($ENV{IDF_PATH}/tools/cmake/idf.cmake)
 project(libespidf C)
 
-idf_build_process($ENV{IDF_TARGET})
+idf_build_process($ENV{IDF_TARGET} SDKCONFIG $ENV{SDKCONFIG} SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS})
 idf_build_get_property(aliases BUILD_COMPONENT_ALIASES)
 
 add_executable(libespidf.elf main.c)

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -82,17 +82,21 @@
 #include "pthread.h"
 #include "esp_pthread.h"
 
+#ifdef CONFIG_ESP32S2_ULP_COPROC_ENABLED
 #ifdef CONFIG_IDF_TARGET_ESP32
 #include "esp32/ulp.h"
 #endif
 
 #ifdef CONFIG_IDF_TARGET_ESP32S2
 #include "esp32s2/ulp.h"
+#ifdef CONFIG_ESP32S2_ULP_COPROC_RISCV
 #include "esp32s2/ulp_riscv.h"
+#endif
 #endif
 
 #ifdef CONFIG_IDF_TARGET_ESP32S3
 #include "esp32s3/ulp.h"
+#endif
 #endif
 
 #ifndef CONFIG_IDF_TARGET_ESP32S2 // No BT in ESP32-S2

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -31,6 +31,7 @@
 
 #include "esp_ota_ops.h"
 
+#include "esp_http_client.h"
 #include "esp_http_server.h"
 
 #include "nvs.h"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod pthread_rwlock;
 
 // ESP-IDF current stable version (4.3) has atomics for ESP32S2, but not for ESP32C3
 // The ESP-IDF master branch has atomics for both
-#[cfg(all(esp32c3, not(feature = "espidf_master")))]
+#[cfg(all(esp32c3, esp_idf_version = "4.3"))]
 mod atomics_esp32c3;
 
 pub use bindings::*;


### PR DESCRIPTION
@N3xed:
Following set of native build fixes:
- Introduction of a new `rustc` cfg: ESP-IDF version. Derived by grepping the generated `bindings.rs` file for three constants (coming from `esp_version.h`: `ESP_IDF_VERSION_MAJOR`, `ESP_IDF_VERSION_MINOR` and `ESP_IDF_VERSION_PATCH`. 
  - Why? Because it works regardless of the concrete build type: be it `pio` or `native`. As to why we are not basing the version on Git tags, that might be difficult as there is e.g. no proper git tag for ESP-IDF master. Als `git describe` returns nothing for `master`. Using the above integers help us e.g. "prepare" the codebase for a release to be branched off from ESP-IDF master, as these are correctly set there (to `4.4.0`)
 
- Bugfix (in `resources/cmake_project/CMakeLists.txt`) as to how the `SDKCONFIG` and `SDKCONFIG_DEFAULTS` were passed to CMake. Your approach was not really working for me. The current one is copy-pasted from google

- Enhancement of the `kconfig` code:
  - Support for `string` values (in addition to tristates). First use case is the `CONFIG_IDF_TARGET` parameter, which is the MCU essentially. Before that, it was derived in a different way for `pio` vs `native`. Bugfixes in `CfgArgs` so that string parameters are properly handled
  - **NOTE**, important: Bugfix: the `json`-based `kconfig` values were not really having the `CONFIG_` prefix, so I am now stripping it from the `.config` based `kconfig` values as well. We might do the other way around as well, especially in light of the fact that some `CfgArgs` might NOT come from `kconfig` values, so having the ESP-IDF `kconfig` values always starting with `esp_idf_config_*` as opposed to just `esp_idf_` is giving us a better namespace separation of sorts.
- Pull of common code from `build_pio.rs` and `build_native.rs` into the main `build.rs` file:
  - Bindgen run
  - Propagation of `CinclArgs`, `LinkArgs` and `CfgArgs`
  - ESP-IDF version grepping
  - Derivation of the MCU string (from `kconfig` ) and computation of the `MCU` configs (`esp32`, `esp32s2`, `esp32c3`)
  - Regexp-based filtering of `kconfig` values. Might be useful in future and is one of your open items, I think
  - Patchsets (~the "master" patchset needs to be re-generated as it doesn't apply cleanly on ESP-IDF master currently, but that would be a separate commit~) *EDIT*: Fixed now.
 
- Again, some Clippy fixes (sorry!)