### PR TITLE
Exclude DAC bindings for esp32s3

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -61,7 +61,7 @@
 
 #include "driver/adc.h"
 #include "driver/twai.h"
-#ifndef CONFIG_IDF_TARGET_ESP32C3
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
 #include "driver/dac.h"
 #endif
 #include "driver/gpio.h"


### PR DESCRIPTION
esp32s3 does not have DAC peripheral.