### PR TITLE
feature: gate mutex rwlock patches for v4.4+

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod start;
 
 // (Temporary code) ESP-IDF does not (yet) have a pthread rwlock implementation, which is required by STD
 // We provide a quick and very hacky implementation here
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", esp_idf_version = "4.3"))]
 mod pthread_rwlock;
 
 // (Temporary code) ESP-IDF current stable version (4.3) has atomics for ESP32S2, but not for ESP32C3
@@ -30,10 +30,13 @@ mod atomics_esp32c3;
 ///
 /// This function will become no-op once ESP-IDF V4.4 is released
 pub fn link_patches() -> (*mut c_types::c_void, *mut c_types::c_void) {
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", esp_idf_version = "4.3"))]
     let rwlock = pthread_rwlock::link_patches();
 
-    #[cfg(not(feature = "std"))]
+    #[cfg(any(
+        not(feature = "std"),
+        not(all(feature = "std", esp_idf_version = "4.3"))
+    ))]
     let rwlock = core::ptr::null_mut();
 
     #[cfg(all(esp32c3, esp_idf_version = "4.3"))]


### PR DESCRIPTION
An official rwlock impl has been implemented in esp-idf (4.4 backport
imminent), hence for versions >4.3 we no longer need to link the patched
versions.

The current pthread rwlock implementation does not support attributes, is this a problem for Rust? I did a quick grep of the standard library and didn't spot any usage...

Closes #33 