### PR TITLE
Unify sdkconfig configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The ESP-IDF API in Rust, with support for each ESP chip (ESP32, ESP32S2, ESP32C3 etc.) based on the Rust target
+The ESP-IDF API in Rust, with support for each ESP chip (ESP32, ESP32S2, ESP32C3 etc.) based on the Rust target.
 
 ![CI](https://github.com/esp-rs/esp-idf-sys/actions/workflows/ci.yml/badge.svg)
 
@@ -13,8 +13,8 @@ The ESP-IDF API in Rust, with support for each ESP chip (ESP32, ESP32S2, ESP32C3
   downloaded during the build by
     - with the feature `pio` (default): utilizing [platformio](https://platformio.org/) (via the [embuild](https://github.com/ivmarkov/embuild) crate) or
     - with the feature `native` (*experimental*): utilizing native `esp-idf` tooling.
-- Check the [ESP-IDF Rust Hello World template crate](https://github.com/esp-rs/esp-idf-template) for a "Hello, world!" Rust template demonstrating how to use and build this crate
-- Check the [demo](https://github.com/ivmarkov/rust-esp32-std-demo) crate for a more comprehensive example in terms of capabilities
+- Check the [ESP-IDF Rust Hello World template crate](https://github.com/esp-rs/esp-idf-template) for a "Hello, world!" Rust template demonstrating how to use and build this crate.
+- Check the [demo](https://github.com/ivmarkov/rust-esp32-std-demo) crate for a more comprehensive example in terms of capabilities.
 
 ## Feature `pio`
 This is currently the default for installing all build tools and building the ESP-IDF framework. It uses [PlatformIO](https://platformio.org/) via the
@@ -57,14 +57,33 @@ TBD: Upcoming
 
 ## Configuration
 
-*NOTE*: This configuration is currently honored *only* by the `native` builder.
-The `pio` (default) builder has a different configuration, but it is not documented here, because in the near future the `pio` builder will also be migrating to 
-the configuration supported by the `native` builder.
+*NOTE*: This configuration is currently only partially honored by the `pio` builder.
+
+The `pio` (default) builder has a different configuration, but it is not documented here,
+because in the near future the `pio` builder will also be migrating to the configuration
+supported by the `native` builder.
 
 Environment variables are used to configure how the `esp-idf` is compiled.
 The following environment variables are used by the build script:
 
-- `ESP_IDF_INSTALL_DIR`:
+- `ESP_IDF_SDKCONFIG_DEFAULTS` (*native* and *pio*): 
+
+    A `;`-separated list of paths to `sdkconfig.default` files to be used as base
+    values for the `sdkconfig`. If such a path is relative, it will be relative to the
+    cargo workspace directory (i.e. the directory that contains the `target` dir).
+
+- `ESP_IDF_SDKCONFIG` (*native* and *pio*): 
+    
+    The path to the `sdkconfig` file used to [configure the
+    `esp-idf`](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html).
+    If this is a relative path, it is relative to the cargo workspace directory.
+
+    **Note** (*native* only):   
+    The cargo optimization options (`debug` and `opt-level`) are used by default to
+    determine the compiler optimizations of the `esp-idf`, **however** if the compiler
+    optimization options are already set in the `sdkconfig` **they will be used instead.**
+
+- `ESP_IDF_INSTALL_DIR` (*native* only):
 
     The path to the directory where all esp-idf tools are installed. If it is set to a
     relative path, it is relative to the crate workspace-dir.
@@ -73,11 +92,12 @@ The following environment variables are used by the build script:
     install dir `~/.espressif`, otherwise it defaults to the local install dir `<crate
     workspace-dir>/.embuild/espressif`.
 
-- `ESP_IDF_GLOBAL_INSTALL`
+- `ESP_IDF_GLOBAL_INSTALL` (*native* only):
 
     If set to `1`, `true`, `y` or `yes` uses the global install directory only when `ESP_IDF_INSTALL_DIR` is not specified.
 
-- `ESP_IDF_VERSION`:
+- `ESP_IDF_VERSION` (*native* only):
+
   The version used for the `esp-idf` can be one of the following:
   - `commit:<hash>`: Uses the commit `<hash>` of the `esp-idf` repository.
                      Note that this will clone the whole `esp-idf` not just one commit.
@@ -86,13 +106,15 @@ The following environment variables are used by the build script:
   - `v<major>.<minor>` or `<major>.<minor>`: Uses the tag `v<major>.<minor>` of the `esp-idf` repository.
   - `<branch>`: Uses the branch `<branch>` of the `esp-idf` repository.
 
-  It defaults to `v4.3`.
-- `ESP_IDF_REPOSITORY`: The URL to the git repository of the `esp-idf`, defaults to <https://github.com/espressif/esp-idf.git>.
-- `ESP_IDF_SDKCONFIG_DEFAULTS`: A `;`-separated list of paths to `sdkconfig.default` files to be used as base
-                                values for the `sdkconfig`.
-- `ESP_IDF_SDKCONFIG`: A path (absolute or relative) to the esp-idf `sdkconfig` file.
-- `MCU`: The mcu name (e.g. `esp32` or `esp32c3`). If not set this will be automatically
-         detected from the cargo target.
+  It defaults to `v4.3.1`.
+- `ESP_IDF_REPOSITORY` (*native* only): 
+
+   The URL to the git repository of the `esp-idf`, defaults to <https://github.com/espressif/esp-idf.git>.
+
+- `MCU` (*native* only): 
+
+   The mcu name (e.g. `esp32` or `esp32c3`). If not set this will be automatically
+   detected from the cargo target.
 
 ## More info
 

--- a/build/native.rs
+++ b/build/native.rs
@@ -15,7 +15,10 @@ use embuild::utils::{OsStrExt, PathExt};
 use embuild::{bindgen, build, cargo, cmake, espidf, git, kconfig, path_buf};
 use strum::{Display, EnumString};
 
-use super::common::{EspIdfBuildOutput, EspIdfComponents, MASTER_PATCHES, STABLE_PATCHES, *};
+use super::common::{
+    self, get_sdkconfig_profile, EspIdfBuildOutput, EspIdfComponents,
+    ESP_IDF_SDKCONFIG_DEFAULTS_VAR, ESP_IDF_SDKCONFIG_VAR, MASTER_PATCHES, STABLE_PATCHES,
+};
 
 const ESP_IDF_INSTALL_DIR_VAR: &str = "ESP_IDF_INSTALL_DIR";
 const ESP_IDF_GLOBAL_INSTALL_VAR: &str = "ESP_IDF_GLOBAL_INSTALL";
@@ -91,7 +94,7 @@ fn build_cmake_first() -> Result<EspIdfBuildOutput> {
 fn build_cargo_first() -> Result<EspIdfBuildOutput> {
     let out_dir = cargo::out_dir();
     let target = env::var("TARGET")?;
-    let workspace_dir = workspace_dir(&out_dir);
+    let workspace_dir = common::workspace_dir(&out_dir);
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
 
     let chip = if let Some(mcu) = env::var_os(MCU_VAR) {
@@ -100,7 +103,7 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
         Chip::detect(&target)?
     };
     let chip_name = chip.to_string();
-    let profile = build_profile();
+    let profile = common::build_profile();
 
     cargo::track_env_var(ESP_IDF_INSTALL_DIR_VAR);
     cargo::track_env_var(ESP_IDF_GLOBAL_INSTALL_VAR);

--- a/build/native.rs
+++ b/build/native.rs
@@ -258,6 +258,7 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
         .out_dir(&out_dir)
         .no_build_target(true)
         .define("CMAKE_TOOLCHAIN_FILE", &cmake_toolchain_file)
+        .define("CMAKE_BUILD_TYPE", "")
         .always_configure(true)
         .pic(false)
         .asmflag(asm_flags)

--- a/build/pio.rs
+++ b/build/pio.rs
@@ -49,8 +49,10 @@ pub fn build() -> Result<EspIdfBuildOutput> {
 
                 (path, format!("sdkconfig.{}", profile).into())
             });
-        let sdkconfig_defaults = env::var_os(ESP_IDF_SDKCONFIG_DEFAULTS_VAR)
-            .unwrap_or_default()
+
+        let sdkconfig_defaults_var =
+            env::var_os(ESP_IDF_SDKCONFIG_DEFAULTS_VAR).unwrap_or_default();
+        let sdkconfig_defaults = sdkconfig_defaults_var
             .try_to_str()?
             .split(';')
             .filter(|v| !v.is_empty())
@@ -60,8 +62,7 @@ pub fn build() -> Result<EspIdfBuildOutput> {
 
                 let file_name = PathBuf::from(path.file_name().unwrap());
                 (path, file_name)
-            })
-            .collect::<Vec<_>>();
+            });
 
         builder
             .enable_scons_dump()
@@ -70,7 +71,7 @@ pub fn build() -> Result<EspIdfBuildOutput> {
             .files(build::tracked_globs_iter(path_buf!["."], &["patches/**"])?)
             .files(build::tracked_env_globs_iter("ESP_IDF_SYS_GLOB")?)
             .files(sdkconfig.into_iter())
-            .files(sdkconfig_defaults.into_iter());
+            .files(sdkconfig_defaults);
 
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
         for patch in STABLE_PATCHES {

--- a/build/pio.rs
+++ b/build/pio.rs
@@ -1,15 +1,13 @@
 //! Install tools and build the `esp-idf` using `platformio`.
 
 use std::convert::TryFrom;
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::{Path, PathBuf};
 
 use anyhow::*;
-
-use embuild::build;
-use embuild::kconfig;
-use embuild::pio;
 use embuild::pio::project;
-use embuild::{bindgen, path_buf};
+use embuild::utils::{OsStrExt, PathExt};
+use embuild::{bindgen, build, cargo, kconfig, path_buf, pio};
 
 use super::common::*;
 
@@ -32,15 +30,47 @@ pub fn build() -> Result<EspIdfBuildOutput> {
             })
             .resolve(true)?;
 
-        let mut builder =
-            project::Builder::new(PathBuf::from(env::var("OUT_DIR")?).join("esp-idf"));
+        let out_dir = cargo::out_dir();
+        let workspace_dir = workspace_dir(&out_dir);
+        let profile = build_profile();
+
+        let mut builder = project::Builder::new(out_dir.join("esp-idf"));
+
+        // Resolve `ESP_IDF_SDKCONFIG` and `ESP_IDF_SDKCONFIG_DEFAULTS` to an absolute path
+        // relative to the workspace directory if not empty.
+        cargo::track_env_var(ESP_IDF_SDKCONFIG_VAR);
+        cargo::track_env_var(ESP_IDF_SDKCONFIG_DEFAULTS_VAR);
+        let sdkconfig = env::var_os(ESP_IDF_SDKCONFIG_VAR)
+            .filter(|v| !v.is_empty())
+            .map(|v| {
+                let path = Path::new(&v).abspath_relative_to(&workspace_dir);
+                let path = get_sdkconfig_profile(&path, &profile, &resolution.mcu).unwrap_or(path);
+                cargo::track_file(&path);
+
+                (path, format!("sdkconfig.{}", profile).into())
+            });
+        let sdkconfig_defaults = env::var_os(ESP_IDF_SDKCONFIG_DEFAULTS_VAR)
+            .unwrap_or_default()
+            .try_to_str()?
+            .split(';')
+            .filter(|v| !v.is_empty())
+            .map(|v| {
+                let path = Path::new(v).abspath_relative_to(&workspace_dir);
+                cargo::track_file(&path);
+
+                let file_name = PathBuf::from(path.file_name().unwrap());
+                (path, file_name)
+            })
+            .collect::<Vec<_>>();
 
         builder
             .enable_scons_dump()
             .enable_c_entry_points()
             .options(build::env_options_iter("ESP_IDF_SYS_PIO_CONF")?)
             .files(build::tracked_globs_iter(path_buf!["."], &["patches/**"])?)
-            .files(build::tracked_env_globs_iter("ESP_IDF_SYS_GLOB")?);
+            .files(build::tracked_env_globs_iter("ESP_IDF_SYS_GLOB")?)
+            .files(sdkconfig.into_iter())
+            .files(sdkconfig_defaults.into_iter());
 
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
         for patch in STABLE_PATCHES {


### PR DESCRIPTION
This mostly implements the plan outlined [here](https://github.com/esp-rs/esp-idf-sys/issues/10#issuecomment-963380205).

Native and pio build now match with the sdkconfig configuration. Though I've implemented in addition to specifying the profile in the file name (like pio required before), that one can now also specify only the mcu or both. Also, the `.<profile>` requirement for pio has been lifted.

Selecting the sdkconfig now has the following precendence:
1. `<path>.<profile>.<chip>`
2. `<path>.<chip>`
3. `<path>.<profile>`
4. `<path>`

For the native build, the optimization configurations now don't conflict anymore. They are set using a generated `sdkconfig.defaults` file from the cargo [`opt-level`](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) and [`debug`](https://doc.rust-lang.org/cargo/reference/profiles.html#debug) settings.

One quirk remains for the native build though: 

When the path to the `sdkconfig` is specified, it is always updated to the configurations used in the latest build. So, if you leave some things unspecified in the `sdkconfig` it will be set after the build, which makes `sdkconfig.defaults` redundant after the first build. Because we copy the files in the pio build this does not happen there (i.e. the sdkconfig used for the build and generated after the build are separate). 
This seems to be intended behavior for normal esp-idf C projects, but doesn't make sense for me. Please tell me what you think about this.
