### PR TITLE
added support for entering/exiting critical sections (disabling inter…

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,0 +1,41 @@
+use crate::*;
+
+// NOTE: ESP-IDF-specific
+const SPINLOCK_FREE_INIT: u32 = 0xB33FFFFF;
+pub type EspCriticalMutex = portMUX_TYPE;
+
+impl EspCriticalMutex {
+    pub fn new() -> Self {
+        Self {
+            owner: SPINLOCK_FREE_INIT,
+            count: 0,
+        }
+    }
+
+    pub fn enter_critical(&mut self) {
+        unsafe { vPortEnterCritical(self) }
+    }
+
+    pub fn exit_critical(&mut self) {
+        unsafe { vPortExitCritical(self) }
+    }
+
+    pub fn scoped(&mut self) -> ScopedCriticalSection {
+        self.enter_critical();
+        ScopedCriticalSection::new(self)
+    }
+}
+
+pub struct ScopedCriticalSection<'a>(&'a mut EspCriticalMutex);
+
+impl<'a> ScopedCriticalSection<'a> {
+    fn new(ecm: &'a mut EspCriticalMutex) -> Self {
+        Self(ecm)
+    }
+}
+
+impl<'a> Drop for ScopedCriticalSection<'a> {
+    fn drop(&mut self) {
+        self.0.exit_critical();
+    }
+}

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -2,9 +2,9 @@ use crate::*;
 
 // NOTE: ESP-IDF-specific
 const SPINLOCK_FREE_INIT: u32 = 0xB33FFFFF;
-pub type EspCriticalMutex = portMUX_TYPE;
+pub type EspCriticalSection = portMUX_TYPE;
 
-impl EspCriticalMutex {
+impl EspCriticalSection {
     pub fn new() -> Self {
         Self {
             owner: SPINLOCK_FREE_INIT,
@@ -26,10 +26,10 @@ impl EspCriticalMutex {
     }
 }
 
-pub struct ScopedCriticalSection<'a>(&'a mut EspCriticalMutex);
+pub struct ScopedCriticalSection<'a>(&'a mut EspCriticalSection);
 
 impl<'a> ScopedCriticalSection<'a> {
-    fn new(ecm: &'a mut EspCriticalMutex) -> Self {
+    fn new(ecm: &'a mut EspCriticalSection) -> Self {
         Self(ecm)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@ pub use error::*;
 pub use mutex::EspMutex;
 
 pub mod error;
+
+#[cfg(not(any(esp32c3, esp32s2, esp32s3, esp32c3)))]
 pub mod interrupts;
+
 pub mod mutex;
 
 mod alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use error::*;
 pub use mutex::EspMutex;
 
 pub mod error;
+pub mod interrupts;
 pub mod mutex;
 
 mod alloc;


### PR DESCRIPTION
Added support for entering and exiting critical sections either manually by calling `enter_critical` and `exit_critical` on `EspCriticalMutex`, or automatically by calling `scoped`.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/freertos-smp.html#critical-sections