### PR TITLE
docs: Add doc build to CI for GH pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,3 +24,12 @@ jobs:
         run: cargo login ${{ secrets.crates_io_token }}
       - name: Build | Publish
         run: export ESP_IDF_TOOLS_INSTALL_DIR=out; export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo publish --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+      - name: Build Documentation
+        run: cargo doc --features native --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort; echo "<meta http-equiv=\"refresh\" content=\"0; url=build_wheel\">" > target/riscv32imc-esp-espidf/doc/index.html; mv target/riscv32imc-esp-espidf/doc ./docs
+      - name: Deploy Documentation
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force_orphan: true
+          publish_dir: ./docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 links = "esp_idf"
 build = "build/build.rs"
+documentation = "https://esp-rs.github.io/esp-idf-sys/"
 
 [features]
 default = ["std", "pio"]


### PR DESCRIPTION
A stop gap until we figure out what to do with regards to docs.rs. The `documentation` key in `Cargo.toml` means crates.io docs button will point to our gh pages link, instead of docs.rs. This has almost all the same features as using docs.rs, however we won't have past versions documentation available once a new version is published.

Currently I've set it to only deploy with releases. 


sidenote: I'll be very shocked if this works first time so expect a follow up PR :D