### PR TITLE
Include the esp_vfs_fat.h header

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -35,6 +35,7 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_pthread_enabled",
     "comp_nvs_flash_enabled",
     "comp_esp_tls_enabled",
+    "comp_esp_vfs_fat_enabled",
     "comp_esp_http_client_enabled",
     "comp_esp_http_server_enabled",
     "comp_espcoredump_enabled",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -46,6 +46,10 @@
 #include "esp_tls.h"
 #endif
 
+#ifdef ESP_IDF_COMP_ESP_VFS_FAT_ENABLED
+#include "esp_vfs_fat.h"
+#endif
+
 #ifdef ESP_IDF_COMP_APP_UPDATE_ENABLED
 #include "esp_ota_ops.h"
 #endif


### PR DESCRIPTION
I needed to use the FatFs driver and want to share my modifications.