### PR TITLE
Default to v4.4

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -18,7 +18,7 @@ pub const MCU_VAR: &str = "MCU";
 pub const SDKCONFIG_FILE: &str = "sdkconfig";
 pub const SDKCONFIG_DEFAULTS_FILE: &str = "sdkconfig.defaults";
 
-pub const STABLE_PATCHES: &[&str] = &[
+pub const FOUR_THREE_PATCHES: &[&str] = &[
     "patches/missing_riscv_atomics_fix.diff",
     "patches/missing_xtensa_atomics_fix.diff",
     "patches/pthread_destructor_fix.diff",

--- a/build/native.rs
+++ b/build/native.rs
@@ -18,14 +18,14 @@ use strum::{Display, EnumString};
 use super::common::{
     self, get_install_dir, list_specific_sdkconfigs, workspace_dir, EspIdfBuildOutput,
     EspIdfComponents, ESP_IDF_GLOB_VAR_PREFIX, ESP_IDF_SDKCONFIG_DEFAULTS_VAR,
-    ESP_IDF_SDKCONFIG_VAR, ESP_IDF_TOOLS_INSTALL_DIR_VAR, MASTER_PATCHES, MCU_VAR, STABLE_PATCHES,
+    ESP_IDF_SDKCONFIG_VAR, ESP_IDF_TOOLS_INSTALL_DIR_VAR, MASTER_PATCHES, MCU_VAR, FOUR_THREE_PATCHES,
 };
 use crate::common::{SDKCONFIG_DEFAULTS_FILE, SDKCONFIG_FILE};
 
 const ESP_IDF_VERSION_VAR: &str = "ESP_IDF_VERSION";
 const ESP_IDF_REPOSITORY_VAR: &str = "ESP_IDF_REPOSITORY";
 
-const DEFAULT_ESP_IDF_VERSION: &str = "v4.3.1";
+const DEFAULT_ESP_IDF_VERSION: &str = "v4.4.0";
 
 const CARGO_CMAKE_BUILD_ACTIVE_VAR: &str = "CARGO_CMAKE_BUILD_ACTIVE";
 const CARGO_CMAKE_BUILD_INCLUDES_VAR: &str = "CARGO_CMAKE_BUILD_INCLUDES";
@@ -139,7 +139,7 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
         git::Ref::Branch(b) if idf.esp_idf.get_default_branch()?.as_ref() == Some(b) => {
             MASTER_PATCHES
         }
-        git::Ref::Tag(t) if t == DEFAULT_ESP_IDF_VERSION => STABLE_PATCHES,
+        git::Ref::Tag(t) if t.starts_with("4.3") => FOUR_THREE_PATCHES,
         _ => {
             cargo::print_warning(format_args!(
                 "`esp-idf` version ({:?}) not officially supported by `esp-idf-sys`. \

--- a/build/native.rs
+++ b/build/native.rs
@@ -18,14 +18,15 @@ use strum::{Display, EnumString};
 use super::common::{
     self, get_install_dir, list_specific_sdkconfigs, workspace_dir, EspIdfBuildOutput,
     EspIdfComponents, ESP_IDF_GLOB_VAR_PREFIX, ESP_IDF_SDKCONFIG_DEFAULTS_VAR,
-    ESP_IDF_SDKCONFIG_VAR, ESP_IDF_TOOLS_INSTALL_DIR_VAR, MASTER_PATCHES, MCU_VAR, FOUR_THREE_PATCHES,
+    ESP_IDF_SDKCONFIG_VAR, ESP_IDF_TOOLS_INSTALL_DIR_VAR, FOUR_THREE_PATCHES, MASTER_PATCHES,
+    MCU_VAR,
 };
 use crate::common::{SDKCONFIG_DEFAULTS_FILE, SDKCONFIG_FILE};
 
 const ESP_IDF_VERSION_VAR: &str = "ESP_IDF_VERSION";
 const ESP_IDF_REPOSITORY_VAR: &str = "ESP_IDF_REPOSITORY";
 
-const DEFAULT_ESP_IDF_VERSION: &str = "v4.4.0";
+const DEFAULT_ESP_IDF_VERSION: &str = "v4.4";
 
 const CARGO_CMAKE_BUILD_ACTIVE_VAR: &str = "CARGO_CMAKE_BUILD_ACTIVE";
 const CARGO_CMAKE_BUILD_INCLUDES_VAR: &str = "CARGO_CMAKE_BUILD_INCLUDES";
@@ -139,7 +140,14 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
         git::Ref::Branch(b) if idf.esp_idf.get_default_branch()?.as_ref() == Some(b) => {
             MASTER_PATCHES
         }
-        git::Ref::Tag(t) if t.starts_with("4.3") => FOUR_THREE_PATCHES,
+        git::Ref::Tag(t) => {
+            if t.starts_with("4.3") {
+                FOUR_THREE_PATCHES
+            } else {
+                // TODO whitelist supported esp-idf tags?
+                &[]
+            }
+        }
         _ => {
             cargo::print_warning(format_args!(
                 "`esp-idf` version ({:?}) not officially supported by `esp-idf-sys`. \

--- a/build/pio.rs
+++ b/build/pio.rs
@@ -100,9 +100,6 @@ pub fn build() -> Result<EspIdfBuildOutput> {
             .files(sdkconfig_defaults);
 
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-        for patch in STABLE_PATCHES {
-            builder.platform_package_patch(manifest_dir.join(patch), path_buf!["framework-espidf"]);
-        }
 
         let project_path = builder.generate(&resolution)?;
 


### PR DESCRIPTION
Sister PR: https://github.com/esp-rs/esp-idf-template/pull/9

AFAIK we can't change the esp-idf version in esp-idf? Therefore I removed the patching for pio.

Marking as draft until pio v4.4 release.