### PR TITLE
build: remove ulp_gcc_toolchain for aarch64 linux

### DIFF
--- a/build/native.rs
+++ b/build/native.rs
@@ -124,7 +124,13 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
 
     let tools = espidf::Tools::new(
         iter::once(chip.gcc_toolchain())
-            .chain(chip.ulp_gcc_toolchain())
+            .chain(
+                if !cfg!(target_os = "linux") && !cfg!(target_arch = "aarch64") {
+                    chip.ulp_gcc_toolchain()
+                } else {
+                    None
+                },
+            )
             .chain(if cmake_generator == cmake::Generator::Ninja {
                 Some("ninja")
             } else {


### PR DESCRIPTION
Together with the [add cmake for aarch64 linux PR](https://github.com/ivmarkov/embuild/pull/41) it should be able to build [std-demo](https://github.com/ivmarkov/rust-esp32-std-demo) on RPi (aarch64 linux).
Closes #14 