### PR TITLE
Fix provisioning of header missing in esp-idf 4.3.1

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -37,13 +37,10 @@
 #include "esp_vfs_cdcacm.h"
 #include "esp_vfs_dev.h"
 #include "esp_vfs_semihost.h"
+
+#if ((ESP_IDF_VERSION_MAJOR > 4) || ((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)))
 #include "esp_vfs_usb_serial_jtag.h"
-
-#if ((ESP_IDF_VERSION_MAJOR > 4) || ((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)))
 #include "esp_vfs_console.h"
-#endif
-
-#if ((ESP_IDF_VERSION_MAJOR > 4) || ((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)))
 #include "esp_vfs_eventfd.h"
 #endif
 


### PR DESCRIPTION
Bulding the latest `rust-esp32-std-demo` (https://github.com/ivmarkov/rust-esp32-std-demo/commit/950d43896b7c37b8d1cba192b0a0d85870c5e103) currently fails due to `esp_vfs_usb_serial_jtag.h` missing in `esp-idf`:
```
$ cargo build --target riscv32imc-esp-espidf
    Updating crates.io index
   Compiling esp-idf-sys v0.30.4
error: failed to run custom build command for `esp-idf-sys v0.30.4`

Caused by:
 [...]
  PACKAGES:
   - framework-espidf 3.40301.0 (4.3.1)
   - tool-cmake 3.16.4
   - tool-esptoolpy 1.30100.210531 (3.1.0)
   - tool-ninja 1.9.0
   - toolchain-riscv32-esp 8.4.0+2021r1
   - toolchain-xtensa-esp32s2 8.4.0+2021r1
  Reading CMake configuration...
[...]
  /[...]/.cargo/registry/src/github.com-1ecc6299db9ec823/esp-idf-sys-0.30.4/src/include/esp-idf/bindings.h:40:10: fatal error: 'esp_vfs_usb_serial_jtag.h' file not found, err: true
  Error: Failed to generate bindings
```

It looks like `esp_vfs_usb_serial_jtag.h` gets provided by `esp-idf` starting with 4.4. This PR makes including this header conditional and groups the conditionally included VFS headers.