### PR TITLE
Add bindings for wifi-provisioning

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -53,6 +53,7 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_soc_enabled",
     "comp_spiffs_enabled",
     "comp_vfs_enabled",
+    "comp_esp_wifi_provisioning_enabled",
 ];
 
 pub struct EspIdfBuildOutput {

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -117,6 +117,12 @@
 #include "nvs_flash.h"
 #endif
 
+#ifdef ESP_IDF_COMP_ESP_WIFI_PROVISIONING_ENABLED
+#include "wifi_provisioning/manager.h"
+#include "wifi_provisioning/scheme_ble.h"
+#include "wifi_provisioning/scheme_softap.h"
+#endif
+
 #ifdef ESP_IDF_COMP_SOC_ENABLED
 // TODO: Include all XXX_periph.h headers here
 #include "soc/gpio_periph.h"


### PR DESCRIPTION
In order to implement wifi-provisioning (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/provisioning/wifi_provisioning.html) the first step is to generate the bindings

That is done here
