### PR TITLE
Patch in `lstat`

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -3,7 +3,10 @@
 #[cfg(all(feature = "std", esp_idf_version = "4.3"))]
 mod pthread_rwlock;
 
-pub struct PatchesRef(*mut crate::c_types::c_void);
+#[cfg(feature = "std")]
+mod lstat;
+
+pub struct PatchesRef(*mut crate::c_types::c_void, *mut crate::c_types::c_void);
 
 /// A hack to make sure that the rwlock implementation is linked to the final executable
 /// Call this function once e.g. in the beginning of your main function
@@ -19,5 +22,10 @@ pub fn link_patches() -> PatchesRef {
     ))]
     let rwlock = core::ptr::null_mut();
 
-    PatchesRef(rwlock)
+    #[cfg(feature = "std")]
+    let lstat = lstat::link_patches();
+    #[cfg(not(feature = "std"))]
+    let lstat = core::ptr::null_mut();
+
+    PatchesRef(rwlock, lstat)
 }

--- a/src/patches/lstat.rs
+++ b/src/patches/lstat.rs
@@ -1,0 +1,13 @@
+use crate::*;
+
+static mut __LSTAT_INTERNAL_REFERENCE: *mut c_types::c_void = lstat as *mut _;
+
+pub fn link_patches() -> *mut c_types::c_void {
+    unsafe { __LSTAT_INTERNAL_REFERENCE }
+}
+
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn lstat(path: *const c_types::c_char, buf: *mut stat) -> c_types::c_int {
+    stat(path, buf)
+}


### PR DESCRIPTION
All filesystems on esp-idf do not support symlinks, there for lstat on espidf platform is the same as stat.

This will be implemented in esp-idf eventually, but for now we can patch it in here.

Partially fixes https://github.com/esp-rs/rust/issues/100.