### PR TITLE
add esp-now support: add bindings for esp_now

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -43,6 +43,7 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_esp_timer_enabled",
     "comp_esp_tls_enabled",
     "comp_esp_wifi_enabled",
+    "comp_esp_espnow_enabled",
     "comp_espcoredump_enabled",
     "comp_fatfs_enabled",
     "comp_mdns_enabled",

--- a/build/common.rs
+++ b/build/common.rs
@@ -43,7 +43,6 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_esp_timer_enabled",
     "comp_esp_tls_enabled",
     "comp_esp_wifi_enabled",
-    "comp_esp_espnow_enabled",
     "comp_espcoredump_enabled",
     "comp_fatfs_enabled",
     "comp_mdns_enabled",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -45,9 +45,7 @@
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_wifi_netif.h"
 #endif
-#ifdef ESP_IDF_COMP_ESP_ESPNOW_ENABLED
 #include "esp_now.h"
-#endif
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_ETH_ENABLED

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -45,6 +45,9 @@
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_wifi_netif.h"
 #endif
+#ifdef ESP_IDF_COMP_ESP_ESPNOW_ENABLED
+#include "esp_now.h"
+#endif
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_ETH_ENABLED


### PR DESCRIPTION
The main PR is in `esp-idf-svc` - this just adds header to the bindings so that they get generated 

related: https://github.com/esp-rs/esp-idf-sys/issues/70