### PR TITLE
enable console component and generate bindings for its header files

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -32,6 +32,7 @@ const TOOLS_WORKSPACE_INSTALL_DIR: &str = ".embuild";
 const ALL_COMPONENTS: &[&str] = &[
     // TODO: Put all IDF components here
     "comp_app_update_enabled",
+    "comp_console_enabled",
     "comp_esp_adc_cal_enabled",
     "comp_esp_eth_enabled",
     "comp_esp_event_enabled",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -16,6 +16,12 @@
 #include "esp_interface.h"
 #include "esp_ipc.h"
 
+#ifdef ESP_IDF_COMP_CONSOLE_ENABLED
+#include "esp_console.h"
+#include "linenoise/linenoise.h"
+#include "argtable3/argtable3.h"
+#endif
+
 #ifdef ESP_IDF_COMP_ESP_PM_ENABLED
 #include "esp_pm.h"
 #endif


### PR DESCRIPTION
To enable use of the ESP-IDF "console" component (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/console.html) in a Rust application, such as a Rust port of the console example apps (https://github.com/espressif/esp-idf/tree/4dc74c9/examples/system/console), this branch enables the component and generates bindings for its esp_console.h, linenoise.h, and argtable3.h header files.