### PR TITLE
Building bindings to bootloader_support component

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -30,6 +30,7 @@ const TOOLS_WORKSPACE_INSTALL_DIR: &str = ".embuild";
 const ALL_COMPONENTS: &[&str] = &[
     // TODO: Put all IDF components here
     "comp_app_update_enabled",
+    "comp_bootloader_support_enabled",
     "comp_console_enabled",
     "comp_esp_adc_cal_enabled",
     "comp_esp_eth_enabled",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -241,4 +241,20 @@
 #include "host/util/util.h"
 #endif
 
+#ifdef ESP_IDF_COMP_BOOTLOADER_SUPPORT_ENABLED
+#include "bootloader_common.h"
+#include "bootloader_clock.h"
+#include "bootloader_flash.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_mem.h"
+#include "bootloader_random.h"
+#include "bootloader_util.h"
+#include "esp_app_format.h"
+#include "esp_flash_data_types.h"
+#include "esp_flash_encrypt.h"
+#include "esp_flash_partitions.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#endif
+
 #endif


### PR DESCRIPTION
Adds the includes from the [bootloader_support](https://github.com/espressif/esp-idf/tree/v4.3.2/components/bootloader_support/include) component and builds them by default. My main interest is access to the `bootloader_random.h` methods detailed in the [Random Number Generation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html#random-number-generation) system API's. I thought it could be useful to add the rest of the bootloader support component while I was there.

I've tried to keep this inline with similar changes but it is my first contribution here, sorry if I've missed any conventions.