### PR TITLE
component: add websocket client

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -53,6 +53,7 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_spiffs_enabled",
     "comp_vfs_enabled",
     "comp_esp_wifi_provisioning_enabled",
+    "comp_esp_ws_client_enabled",
 ];
 
 pub struct EspIdfBuildOutput {

--- a/build/common.rs
+++ b/build/common.rs
@@ -53,7 +53,7 @@ const ALL_COMPONENTS: &[&str] = &[
     "comp_spiffs_enabled",
     "comp_vfs_enabled",
     "comp_esp_wifi_provisioning_enabled",
-    "comp_esp_ws_client_enabled",
+    "comp_esp_websocket_client_enabled",
 ];
 
 pub struct EspIdfBuildOutput {

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -62,7 +62,7 @@
 #endif
 #endif
 
-#ifdef ESP_IDF_COMP_ESP_WS_CLIENT_ENABLED
+#ifdef ESP_IDF_COMP_ESP_WEBSOCKET_CLIENT_ENABLED
 #include "esp_websocket_client.h"
 #endif
 

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -62,6 +62,10 @@
 #endif
 #endif
 
+#ifdef ESP_IDF_COMP_ESP_WS_CLIENT_ENABLED
+#include "esp_websocket_client.h"
+#endif
+
 #ifdef ESP_IDF_COMP_VFS_ENABLED
 #include "esp_vfs.h"
 #include "esp_vfs_cdcacm.h"


### PR DESCRIPTION
Adds the WebSocket client to enable implementation of it in `esp-idf-svc`.