### PR TITLE
Use a build matrix to also build for xtensa architectures

### DIFF
--- a/.github/configs/sdkconfig.defaults
+++ b/.github/configs/sdkconfig.defaults
@@ -1,3 +1,0 @@
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,48 @@ on:
   schedule:
     - cron: '50 4 * * *'
 
-env:
-  rust_toolchain: nightly
-
 jobs:
   compile:
     name: Compile
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - riscv32imc-esp-espidf
+          - xtensa-esp32-espidf
+          - xtensa-esp32s2-espidf
+          - xtensa-esp32s3-espidf
+
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
+
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.rust_toolchain }}
+          default: true
+          toolchain: nightly
           components: rustfmt, clippy
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
       - name: Setup | Std
-        run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default ${{ env.rust_toolchain }}
+        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
+      - name: Install Rust for Xtensa
+        uses: esp-rs/xtensa-toolchain@v1.2.0
+        with:
+          default: true
+        if: matrix.target != 'riscv32imc-esp-espidf'
+
       - name: Build | Fmt Check
         run: cargo fmt -- --check
+
       - name: Build | Clippy (PIO)
-        run: export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo clippy --features pio --no-deps --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
+        run: cargo clippy --features pio --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
+        if: matrix.target == 'riscv32imc-esp-espidf'
+
       - name: Build | Compile (Native) / ESP-IDF V4.4
-        run: export ESP_IDF_VERSION=release/v4.4; cargo build --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+        env:
+          ESP_IDF_VERSION: release/v4.4


### PR DESCRIPTION
~~Requires https://github.com/esp-rs/xtensa-toolchain/pull/6 to be merged first.~~ This is now merged.

I was able to delete `.github/configs/sdkconfig.defaults` since it's no longer required. If you like this, I will also do this for the other workflows in this repo as well as for the other esp-rs repos.