### PR TITLE
Include headers for NimBLE GAP & GATT services

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -273,6 +273,8 @@
 #include "nimble/nimble_port_freertos.h"
 #include "host/ble_hs.h"
 #include "host/util/util.h"
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
 #endif
 
 #endif


### PR DESCRIPTION
Not absolutely essential, but the functions in these headers make setting up BLE applications a lot easier!