### PR TITLE
Upgrade embuild, bindgen, add automatic tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - riscv32imc-esp-espidf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   rust_toolchain: nightly
+  CRATE_NAME: esp-idf-sys
 
 jobs:
   publish:
@@ -34,3 +35,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force_orphan: true
           publish_dir: ./docs
+      - name: Get the crate version from cargo
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{env.CRATE_NAME}}\") | .version")
+          echo "crate_version=$version" >> $GITHUB_ENV
+          echo "${{env.CRATE_NAME}} version: $version"
+      - name: Tag the new release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: v${{env.crate_version}}
+          message: "Release v${{env.crate_version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ pio = ["embuild/pio"]
 paste = "1"
 
 [build-dependencies]
-embuild = { version = "0.29", features = ["glob"] }
+embuild = { version = "0.30", features = ["glob", "kconfig"] }
 anyhow = "1"
 strum = { version = "0.24", features = ["derive"], optional = true }
 regex = "1.5"
-bindgen = "0.59"
+bindgen = "0.60"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The following environment variables are used by the build script:
   - `v<major>.<minor>` or `<major>.<minor>`: Uses the tag `v<major>.<minor>` of the `esp-idf` repository.
   - `<branch>`: Uses the branch `<branch>` of the `esp-idf` repository.
 
-  It defaults to `v4.3.2`.
+  It defaults to `v4.4.1`.
 
 
 - `ESP_IDF_REPOSITORY` (*native* builder only): 

--- a/build/native.rs
+++ b/build/native.rs
@@ -359,11 +359,12 @@ fn build_cargo_first() -> Result<EspIdfBuildOutput> {
     let (asm_flags, c_flags, cxx_flags) = {
         let extractor_script = cmake::script_variables_extractor(&cmake_toolchain_file)?;
 
-        let output = embuild::cmd_output!(
+        let output = embuild::cmd!(
             cmake::cmake(),
             "-P",
             extractor_script.as_ref().as_os_str();
-            env=("IDF_PATH", &idf.repository.worktree().as_os_str()))?;
+            env=("IDF_PATH", &idf.repository.worktree().as_os_str()))
+        .stdout()?;
 
         let mut vars = cmake::process_script_variables_extractor_output(output)?;
         (


### PR DESCRIPTION
- Upgrade `embuild` to 0.30
- Upgrade bindgen to 0.60
- Add automatic release tagging on publish

Nothing groundbreaking, just upgrading embuild (and with it bindgen) for which I've just published a new major version. I've also added to embuild, and now here, automatic tagging to the publish workflow. It tags the current revision with a `v<crate version>` tag. Additionally, I've changed the tag format (it was only `<version>` before) to `v<version>` to make it more consistent with our other repositories.

Fixes #53 