### PR TITLE
Feature/specify built components

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ The following configuration options are available:
    > ⚠️
    > [Older ESP-IDF versions might not support all MCUs from above.](https://github.com/espressif/esp-idf#esp-idf-release-and-soc-compatibility)
    
+- ### *`esp_idf_components`*, `$ESP_IDF_COMPONENTS` (*native* builder only)
+
+    The list of esp-idf components (names) that should be built. This list is used to
+    trim the esp-idf build. Any component that is a dependency of a component in this
+    list will also automatically be built.
+    
+    Defaults to all components being built.
+    
+    > &#128712; **Note**  
+    > Some components must be explicitly enabled in the sdkconfig.  
+    > [Extra components](#extra-esp-idf-components) must also be added to this list if
+    > they are to be built.
+
 ### Example
 
 An example of the `[package.metadata.esp-idf-sys]` section of the `Cargo.toml`.

--- a/build/native/cargo_driver.rs
+++ b/build/native/cargo_driver.rs
@@ -317,6 +317,11 @@ pub fn build() -> Result<EspIdfBuildOutput> {
         cmake_config.env("IDF_TOOLS_PATH", install_dir);
     }
 
+    // specify the components that should be built
+    if let Some(components) = &config.native.esp_idf_components {
+        cmake_config.env("COMPONENTS", components.join(";"));
+    }
+
     // Build the esp-idf.
     cmake_config.build();
 
@@ -372,6 +377,8 @@ pub fn build() -> Result<EspIdfBuildOutput> {
             c => Some(c.to_string()),
         })
         .collect::<Vec<_>>();
+
+    eprintln!("Built components: {}", components.join(", "));
 
     let sdkconfig_json = path_buf![&cmake_build_dir, "config", "sdkconfig.json"];
     let build_output = EspIdfBuildOutput {

--- a/resources/cmake_project/CMakeLists.txt
+++ b/resources/cmake_project/CMakeLists.txt
@@ -8,7 +8,12 @@ foreach(component_dir IN ITEMS $ENV{EXTRA_COMPONENT_DIRS})
     idf_build_component(${component_dir})
 endforeach()
 
-idf_build_process($ENV{IDF_TARGET} SDKCONFIG $ENV{SDKCONFIG} SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS})
+if(DEFINED ENV{COMPONENTS})
+    idf_build_process($ENV{IDF_TARGET} SDKCONFIG $ENV{SDKCONFIG} SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS} COMPONENTS $ENV{COMPONENTS})
+else()
+    idf_build_process($ENV{IDF_TARGET} SDKCONFIG $ENV{SDKCONFIG} SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS})
+endif()
+
 idf_build_get_property(aliases BUILD_COMPONENT_ALIASES)
 
 add_executable(libespidf.elf main.c)


### PR DESCRIPTION
Add `$ESP_IDF_COMPONENTS` and `esp_idf_components` configuration options that allow to specify a list of esp-idf components to build. This list can be used to trim down the esp-idf build and reduce compile time.
Only implemented for the native build driver.

Fixes #83