### PR TITLE
Add usb host to bindings

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -209,6 +209,12 @@
 #include "esp_pthread.h"
 #endif
 
+#ifdef ESP_IDF_COMP_USB_ENABLED
+#ifdef CONFIG_USB_OTG_SUPPORTED
+#include "usb/usb_host.h"
+#endif
+#endif
+
 #ifdef ESP_IDF_COMP_ULP_ENABLED
 #if (ESP_IDF_VERSION_MAJOR > 4)
 // ESP-IDF V5+


### PR DESCRIPTION
Usb host component is missing in esp-idf-sys bindings. By using this variable `CONFIG_USB_OTG_SUPPORTED` we can depend on header only being picked up on supported boards. It is currently enabled for [ESP32 S3](https://github.com/espressif/esp-idf/blob/2b1bee166d4d5b55549063e93a4c1be86e9c9da3/components/soc/esp32s3/include/soc/soc_caps.h#L40)   and for [ESP32 S2](https://github.com/espressif/esp-idf/blob/2b1bee166d4d5b55549063e93a4c1be86e9c9da3/components/soc/esp32s2/include/soc/soc_caps.h#L49).