### PR TITLE
Fix output directory for globs

### DIFF
--- a/build/native/cargo_driver.rs
+++ b/build/native/cargo_driver.rs
@@ -211,7 +211,7 @@ pub fn build() -> Result<EspIdfBuildOutput> {
         fs::create_dir_all(dest_path.parent().unwrap())?;
         // TODO: Maybe warn if this overwrites a critical file (e.g. CMakeLists.txt).
         // It could be useful for the user to explicitly overwrite our files.
-        copy_file_if_different(&file.0, &out_dir)?;
+        copy_file_if_different(&file.0, &dest_path)?;
     }
 
     // Resolve the `sdkconfig` and all `sdkconfig.defaults` files specified in the build


### PR DESCRIPTION
This is a partial fix for #127.

Previously, user specified globs were placed in the root directory of dummy C project, rather than in the created folder.

## Partial fix
This is a partial fix, because the glob works with wildcards like `certs/*`, but doesn't work with wildcards like `certs*`, the crate [globwalk](https://crates.io/crates/globwalk) used for finding files doesn't return the right list of files when using `certs*`.
We have two choices:
1. Edit the README.md to change mentions of `foo*` and `bar*` to `foor/*` and `bar/*`
2. Fix the way embuild, the crate used for copying files, finds files.  
https://github.com/esp-rs/embuild/blob/5e12da302f372c05d20a149b00eca1befde185f6/src/build.rs#L95-L114

## Example
```toml
ESP_IDF_GLOB_CRT_BASE = { value = ".", relative = true}
ESP_IDF_GLOB_CRT_CERT = "certs/certificate.pem"
```

```
.
├── Cargo.lock
├── Cargo.toml
├── certs/
     └── certificate.pem
├── README.md
├── rust-toolchain.toml
├── sdkconfig.defaults
└── src
     └── main.rs
```

This will put the file `certificate.pem` in the directory `certs` at the root of the dummy C project
```
.
├── bindings.rs
├── build
│   └── ...
├── certs
│   └── certificate.pem
├── CMakeLists.txt
├── esp-idf-build.json
├── gen-sdkconfig.defaults
├── main.c
└── sdkconfig
```