### PR TITLE
Fix wrong section name in esp_app_desc macro

### DIFF
--- a/src/app_desc.rs
+++ b/src/app_desc.rs
@@ -3,7 +3,7 @@ macro_rules! esp_app_desc {
     () => {
         #[no_mangle]
         #[used]
-        #[link_section = ".rodata.desc"]
+        #[link_section = ".rodata_desc"]
         #[allow(non_upper_case_globals)]
         pub static esp_app_desc: $crate::esp_app_desc_t = {
             const fn str_to_cstr_array<const C: usize>(s: &str) -> [$crate::c_types::c_char; C] {


### PR DESCRIPTION
Accordingly to linker scripts(`components/esp_system/ld/esp32s3/sections.ld.in` and others) and previously add patches application description is stored in `rodata_desc` section. Changing this brought app descriptor back to the beginning of binary file.