### PR TITLE
Initialize target specific information in CMake

### DIFF
--- a/resources/cmake_project/CMakeLists.txt
+++ b/resources/cmake_project/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 
+include($ENV{IDF_PATH}/tools/cmake/targets.cmake)
+__target_init()
+
 include($ENV{IDF_PATH}/tools/cmake/idf.cmake)
 project(libespidf C)
 

--- a/resources/cmake_project/CMakeLists.txt
+++ b/resources/cmake_project/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-include($ENV{IDF_PATH}/tools/cmake/targets.cmake)
-__target_init()
+set(IDF_TARGET $ENV{IDF_TARGET} CACHE STRING "IDF Build Target")
 
 include($ENV{IDF_PATH}/tools/cmake/idf.cmake)
 project(libespidf C)


### PR DESCRIPTION
related to espressif/esp-idf#10082 which is caused by this being absent