### PR TITLE
choose pcnt implementation on esp-idf 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ panic_handler = []
 binstart = []
 libstart = []
 
+# by default esp-idf-sys includes driver/pulse_cnt.h when enabled driver/pcnt.h
+# will be included instead (only used when compiling esp-idf > 4, esp-idf 4 always
+# incudes driver/pcnt.h)
+pcnt4 = []
+
 # Use native `esp-idf` tooling to build the `esp-idf`
 native = ["embuild/cmake", "embuild/espidf"]
 # Backup: use `platformio` to build the `esp-idf`

--- a/build/build.rs
+++ b/build/build.rs
@@ -94,7 +94,10 @@ fn main() -> anyhow::Result<()> {
 
     // if the pulse_cnt.h header (proxy for esp-idf version > 4) is available then use the pcnt4 feature to
     // choose between old and new implementations
-    let pulse_cnt_available = build_output.esp_idf.join("components/driver/include/driver/pulse_cnt.h").exists();
+    let pulse_cnt_available = build_output
+        .esp_idf
+        .join("components/driver/include/driver/pulse_cnt.h")
+        .exists();
     let pcnt_header_name = match pulse_cnt_available {
         #[cfg(feature = "pcnt4")]
         true => "bindings_pcnt.h",

--- a/build/build.rs
+++ b/build/build.rs
@@ -92,7 +92,25 @@ fn main() -> anyhow::Result<()> {
         "bindings.h"
     ];
 
+    #[cfg(any(feature = "pcnt4", esp_idf_version_major = "4"))]
+    let pcnt_header_name = "bindings_pcnt.h";
+    #[cfg(not(any(feature = "pcnt4", esp_idf_version_major = "4")))]
+    let pcnt_header_name = "bindings_pulse_cnt.h";
+
+    let pcnt_header_file = path_buf![
+        &manifest_dir,
+        "src",
+        "include",
+        if mcu == "esp8266" {
+            "esp-8266-rtos-sdk"
+        } else {
+            "esp-idf"
+        },
+        pcnt_header_name
+    ];
+
     cargo::track_file(&header_file);
+    cargo::track_file(&pcnt_header_file);
 
     // Because we have multiple bindgen invocations and we can't clone a bindgen::Builder,
     // we have to set the options every time.
@@ -129,7 +147,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     #[allow(unused_mut)]
-    let mut headers = vec![header_file];
+    let mut headers = vec![header_file, pcnt_header_file];
 
     #[cfg(all(feature = "native", not(feature = "pio")))]
     // Add additional headers from extra components.

--- a/src/include/esp-8266-rtos-sdk/bindings_pcnt.h
+++ b/src/include/esp-8266-rtos-sdk/bindings_pcnt.h
@@ -1,0 +1,1 @@
+/* intentionaly empty - esp8266 has no pulse counter */

--- a/src/include/esp-8266-rtos-sdk/bindings_pulse_cnt.h
+++ b/src/include/esp-8266-rtos-sdk/bindings_pulse_cnt.h
@@ -1,0 +1,1 @@
+/* intentionaly empty - esp8266 has no pulse counter */

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -181,9 +181,6 @@
 #else
 #include "driver/mcpwm.h"
 #endif
-#ifndef CONFIG_IDF_TARGET_ESP32C3
-#include "driver/pcnt.h"
-#endif
 #include "driver/periph_ctrl.h"
 #include "driver/rmt.h"
 #include "driver/rtc_cntl.h"

--- a/src/include/esp-idf/bindings_pcnt.h
+++ b/src/include/esp-idf/bindings_pcnt.h
@@ -1,0 +1,3 @@
+#ifndef CONFIG_IDF_TARGET_ESP32C3
+#include "driver/pcnt.h"
+#endif

--- a/src/include/esp-idf/bindings_pulse_cnt.h
+++ b/src/include/esp-idf/bindings_pulse_cnt.h
@@ -1,0 +1,3 @@
+#ifndef CONFIG_IDF_TARGET_ESP32C3
+#include "driver/pulse_cnt.h"
+#endif


### PR DESCRIPTION
add feature to select esp-idf 4 pcnt implementation or
esp-idf5 pulse_cnt (v4 always gets pcnt)
default on esp-idf 5 is pulse_cnt
