### PR TITLE
Move to `bindgen` 0.63, `core::ffi` `size_t` = `usize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ const_format = "0.2" # For esp_app_desc!()
 embuild = { version = "0.30.4", features = ["glob", "kconfig"] }
 anyhow = "1"
 regex = "1.5"
-bindgen = "0.60"
+bindgen = "0.63"
 cargo_metadata = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 strum = { version = "0.24", features = ["derive"] }

--- a/build/build.rs
+++ b/build/build.rs
@@ -99,7 +99,8 @@ fn main() -> anyhow::Result<()> {
     let configure_bindgen = |bindgen: bindgen::Builder| {
         Ok(bindgen
             .parse_callbacks(Box::new(BindgenCallbacks))
-            .ctypes_prefix("c_types")
+            .use_core()
+            .enable_function_attribute_detection()
             .blocklist_function("strtold")
             .blocklist_function("_strtold_r")
             .blocklist_function("v.*printf")

--- a/build/common.rs
+++ b/build/common.rs
@@ -24,7 +24,10 @@ pub const V_4_3_2_PATCHES: &[&str] = &[
 pub const MASTER_PATCHES: &[&str] = &[];
 
 #[allow(dead_code)]
-pub const V_4_4_2_PATCHES: &[&str] = &["patches/esp_app_format_weak_v4.4.diff"];
+pub const V_5_0_PATCHES: &[&str] = &["patches/esp_app_format_weak_v5.0.diff"];
+
+#[allow(dead_code)]
+pub const V_4_4_3_PATCHES: &[&str] = &["patches/esp_app_format_weak_v4.4.diff"];
 
 const TOOLS_WORKSPACE_INSTALL_DIR: &str = ".embuild";
 

--- a/build/native/cargo_driver.rs
+++ b/build/native/cargo_driver.rs
@@ -17,7 +17,7 @@ use embuild::{bindgen, build, cargo, cmake, espidf, git, kconfig, path_buf};
 use self::chip::Chip;
 use crate::common::{
     self, list_specific_sdkconfigs, manifest_dir, workspace_dir, EspIdfBuildOutput,
-    EspIdfComponents, InstallDir, MASTER_PATCHES, V_4_3_2_PATCHES, V_4_4_2_PATCHES,
+    EspIdfComponents, InstallDir, MASTER_PATCHES, V_4_3_2_PATCHES, V_4_4_3_PATCHES, V_5_0_PATCHES,
 };
 use crate::config::{BuildConfig, ESP_IDF_GLOB_VAR_PREFIX, ESP_IDF_TOOLS_INSTALL_DIR_VAR};
 
@@ -185,13 +185,15 @@ pub fn build() -> Result<EspIdfBuildOutput> {
             {
                 MASTER_PATCHES
             }
+            Ok((5, 0, _)) => V_5_0_PATCHES,
             Ok((5, _, _)) => MASTER_PATCHES,
-            Ok((4, 4, _)) => V_4_4_2_PATCHES,
+            Ok((4, 4, _)) => V_4_4_3_PATCHES,
             Ok((4, 3, 2)) => V_4_3_2_PATCHES,
             Ok((major, minor, patch)) => {
                 cargo::print_warning(format_args!(
                     "esp-idf version ({major}.{minor}.{patch}) not officially supported by `esp-idf-sys`. \
-                     Supported versions are 'master', 'release/v4.4', 'release/v4.3', 'v4.4(.X)', 'v4.3.3', 'v4.3.2'.",
+                     Supported versions are 'master', 'release/v5.0', 'release/v4.4', 'release/v4.3', \
+                     'v5.0(.X)', 'v4.4(.X)', 'v4.3.3', 'v4.3.2'.",
                 ));
                 &[]
             }

--- a/patches/esp_app_format_weak_v5.0.diff
+++ b/patches/esp_app_format_weak_v5.0.diff
@@ -1,0 +1,13 @@
+diff --git a/components/esp_app_format/esp_app_desc.c b/components/esp_app_format/esp_app_desc.c
+index 909bb94a4c..851fdb9eb6 100644
+--- a/components/esp_app_format/esp_app_desc.c
++++ b/components/esp_app_format/esp_app_desc.c
+@@ -12,7 +12,7 @@
+ 
+ 
+ // Application version info
+-const __attribute__((section(".rodata_desc"))) esp_app_desc_t esp_app_desc = {
++const __attribute__((weak)) __attribute__((section(".rodata_desc"))) esp_app_desc_t esp_app_desc = {
+     .magic_word = ESP_APP_DESC_MAGIC_WORD,
+ #ifdef CONFIG_APP_EXCLUDE_PROJECT_VER_VAR
+     .version = "",

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -11,10 +11,7 @@ static HEAP: Esp32Alloc = Esp32Alloc;
 #[cfg_attr(not(feature = "std"), alloc_error_handler)]
 #[allow(dead_code)]
 fn on_oom(_layout: Layout) -> ! {
-    unsafe {
-        crate::abort();
-        core::hint::unreachable_unchecked();
-    }
+    unsafe { abort() }
 }
 
 struct Esp32Alloc;

--- a/src/app_desc.rs
+++ b/src/app_desc.rs
@@ -6,8 +6,8 @@ macro_rules! esp_app_desc {
         #[link_section = ".rodata_desc"]
         #[allow(non_upper_case_globals)]
         pub static esp_app_desc: $crate::esp_app_desc_t = {
-            const fn str_to_cstr_array<const C: usize>(s: &str) -> [$crate::c_types::c_char; C] {
-                let mut ret: [$crate::c_types::c_char; C] = [0; C];
+            const fn str_to_cstr_array<const C: usize>(s: &str) -> [::core::ffi::c_char; C] {
+                let mut ret: [::core::ffi::c_char; C] = [0; C];
 
                 let mut i = 0;
                 while i < C {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use core::{fmt, slice, str};
+use core::{ffi, fmt, slice, str};
 
-use crate::{c_types, esp_err_t, esp_err_to_name, ESP_OK};
+use crate::{esp_err_t, esp_err_to_name, ESP_OK};
 
 /// A wrapped [`esp_err_t`] to check if an error occurred.
 ///
@@ -56,7 +56,7 @@ impl std::error::Error for EspError {}
 
 impl fmt::Display for EspError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe fn strlen(c_s: *const c_types::c_char) -> usize {
+        unsafe fn strlen(c_s: *const ffi::c_char) -> usize {
             let mut len = 0;
             while *c_s.offset(len) != 0 {
                 len += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,49 +45,6 @@ pub fn link_patches() -> PatchesRef {
     patches::link_patches()
 }
 
-#[cfg(feature = "std")]
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-pub mod c_types {
-    pub type c_void = std::os::raw::c_void;
-    pub type c_uchar = std::os::raw::c_uchar;
-    pub type c_schar = std::os::raw::c_schar;
-    pub type c_char = std::os::raw::c_char;
-    pub type c_short = std::os::raw::c_short;
-    pub type c_ushort = std::os::raw::c_ushort;
-    pub type c_int = std::os::raw::c_int;
-    pub type c_uint = std::os::raw::c_uint;
-    pub type c_long = std::os::raw::c_long;
-    pub type c_ulong = std::os::raw::c_ulong;
-    pub type c_longlong = std::os::raw::c_longlong;
-    pub type c_ulonglong = std::os::raw::c_ulonglong;
-}
-
-#[cfg(not(feature = "std"))]
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-pub mod c_types {
-    pub type c_void = core::ffi::c_void;
-    pub type c_uchar = u8;
-    pub type c_schar = i8;
-    // Even though libc and STD do use a signed char type for both RiscV & Xtensa,
-    // we need to switch to unsigned char for no_std + RiscV in order to match what
-    // is currently hard-coded in the cty crate (used by the CStr & CString impls in no_std):
-    // https://github.com/japaric/cty/blob/master/src/lib.rs#L30
-    #[cfg(target_arch = "riscv32")]
-    pub type c_char = u8;
-    #[cfg(not(target_arch = "riscv32"))]
-    pub type c_char = i8;
-    pub type c_short = i16;
-    pub type c_ushort = u16;
-    pub type c_int = i32;
-    pub type c_uint = u32;
-    pub type c_long = i32;
-    pub type c_ulong = u32;
-    pub type c_longlong = i64;
-    pub type c_ulonglong = u64;
-}
-
 #[allow(clippy::all)]
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
@@ -95,7 +52,5 @@ pub mod c_types {
 #[allow(rustdoc::all)]
 #[allow(improper_ctypes)] // TODO: For now, as 5.0 spits out tons of these
 mod bindings {
-    use super::c_types;
-
     include!(env!("EMBUILD_GENERATED_BINDINGS_FILE"));
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -3,8 +3,5 @@
 #[cfg_attr(not(feature = "std"), panic_handler)]
 #[allow(dead_code)]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
-    unsafe {
-        crate::abort();
-        core::hint::unreachable_unchecked();
-    }
+    unsafe { crate::abort() }
 }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -6,7 +6,7 @@ mod pthread_rwlock;
 #[cfg(feature = "std")]
 mod lstat;
 
-pub struct PatchesRef(*mut crate::c_types::c_void, *mut crate::c_types::c_void);
+pub struct PatchesRef(*mut core::ffi::c_void, *mut core::ffi::c_void);
 
 /// A hack to make sure that the rwlock implementation is linked to the final executable
 /// Call this function once e.g. in the beginning of your main function

--- a/src/patches/lstat.rs
+++ b/src/patches/lstat.rs
@@ -1,13 +1,14 @@
 use crate::*;
+use core::ffi;
 
-static mut __LSTAT_INTERNAL_REFERENCE: *mut c_types::c_void = lstat as *mut _;
+static mut __LSTAT_INTERNAL_REFERENCE: *mut ffi::c_void = lstat as *mut _;
 
-pub fn link_patches() -> *mut c_types::c_void {
+pub fn link_patches() -> *mut ffi::c_void {
     unsafe { __LSTAT_INTERNAL_REFERENCE }
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn lstat(path: *const c_types::c_char, buf: *mut stat) -> c_types::c_int {
+pub unsafe extern "C" fn lstat(path: *const ffi::c_char, buf: *mut stat) -> ffi::c_int {
     stat(path, buf)
 }

--- a/src/patches/pthread_rwlock.rs
+++ b/src/patches/pthread_rwlock.rs
@@ -2,67 +2,67 @@
 // https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Using_a_condition_variable_and_a_mutex
 
 use crate::*;
+use core::ffi;
 
-static mut __PTHREAD_RWLOCK_INTERNAL_REFERENCE: *mut c_types::c_void =
-    pthread_rwlock_init as *mut _;
+static mut __PTHREAD_RWLOCK_INTERNAL_REFERENCE: *mut ffi::c_void = pthread_rwlock_init as *mut _;
 
-pub fn link_patches() -> *mut c_types::c_void {
+pub fn link_patches() -> *mut ffi::c_void {
     unsafe { __PTHREAD_RWLOCK_INTERNAL_REFERENCE }
 }
 
 #[no_mangle]
 #[inline(never)]
 pub unsafe extern "C" fn pthread_rwlock_init(
-    rwlock: *mut c_types::c_void,
-    attr: *const c_types::c_void,
-) -> c_types::c_int {
+    rwlock: *mut ffi::c_void,
+    attr: *const ffi::c_void,
+) -> ffi::c_int {
     pthread_mutex_init(rwlock as *mut _, attr as *const _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_lock(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_tryrdlock(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_tryrdlock(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_trylock(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_lock(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_trywrlock(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_trywrlock(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_trylock(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_unlock(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutex_destroy(rwlock as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlockattr_init(attr: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlockattr_init(attr: *mut ffi::c_void) -> ffi::c_int {
     pthread_mutexattr_init(attr as *mut _)
 }
 
 #[no_mangle]
 #[inline(never)]
-pub unsafe extern "C" fn pthread_rwlockattr_destroy(attr: *mut c_types::c_void) -> c_types::c_int {
+pub unsafe extern "C" fn pthread_rwlockattr_destroy(attr: *mut ffi::c_void) -> ffi::c_int {
     pthread_rwlockattr_init(attr as *mut _)
 }


### PR DESCRIPTION
- reintroduce `esp_app_desc` patch for v5.0
- move to `bindgen` 0.63, `core::ffi` `size_t` = `usize`
- Requires esp-rs/embuild#66