### PR TITLE
Remove libncurses5 installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '50 4 * * *'
-    
+    - cron: "50 4 * * *"
+
 env:
   rust_nightly_toolchain: nightly
 
@@ -27,9 +27,6 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
-      
-      - name: Setup | libncurses5
-        run: sudo apt-get install libncurses5
 
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
@@ -44,7 +41,7 @@ jobs:
         if: matrix.target == 'riscv32imc-esp-espidf'
 
       - name: Install Rust for Xtensa
-        uses: esp-rs/xtensa-toolchain@v1.2.0
+        uses: esp-rs/xtensa-toolchain@v1.4.0
         with:
           default: true
         if: matrix.target != 'riscv32imc-esp-espidf'


### PR DESCRIPTION
- Starting in `1.66.0.0` script installer and version `0.2.4` of `espup`, `libncurses5` is no longer required as we use the [latest llvm release](https://github.com/espressif/llvm-project/releases/tag/esp-15.0.0-20221201)
- Update `xtensa-toolchain` action release. This release has an ongoing issue, see https://github.com/esp-rs/xtensa-toolchain/issues/15.
  - We will be publishing a new release for the action shortly.