### PR TITLE
Enable WPA2 bindings

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -63,6 +63,7 @@
 #endif
 #include "esp_now.h"
 #include "esp_mesh.h"
+#include "esp_wpa2.h"
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_ETH_ENABLED


### PR DESCRIPTION
With this `include` added, bindings to the `esp_wifi_sta_wpa2_*` functions will be generated, which enable the usage of WPA2 Enterprise authentication.