### PR TITLE
Add Bluedroid A2DP and AVRC profile implementations

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -312,6 +312,8 @@
 #include "esp_bt_main.h"
 #include "esp_gap_bt_api.h"
 #include "esp_bt_device.h"
+#include "esp_a2dp_api.h"
+#include "esp_avrc_api.h"
 #endif
 
 #ifdef CONFIG_BT_NIMBLE_ENABLED


### PR DESCRIPTION
Make additional ESP-IDF functionality available: the IDF libraries for Bluetooth profiles Advanced Audio Distribution Profile (A2DP) and Audio / Video Remote Control.