### PR TITLE
Define `ESP_PLATFORM`

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -101,6 +101,7 @@ fn main() -> anyhow::Result<()> {
             .parse_callbacks(Box::new(BindgenCallbacks))
             .use_core()
             .enable_function_attribute_detection()
+            .clang_arg("-DESP_PLATFORM")
             .blocklist_function("strtold")
             .blocklist_function("_strtold_r")
             .blocklist_function("v.*printf")


### PR DESCRIPTION
Fixes https://github.com/esp-rs/esp-idf-sys/issues/185

Unfortunately, this is a breaking change because it changes some of the FreeRTOS functions to take and return `*c_void` instead of `*tskTaskControlBlock`. Possible some other things, too, but this is the only change I encountered. Since this PR is a correctness fix, I think this breakage is justified.