### PR TITLE
Include the I2S 5.x driver headers.

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -204,6 +204,11 @@
 #include "driver/i2s.h"
 #include "driver/ledc.h"
 #if ESP_IDF_VERSION_MAJOR > 4
+#include "driver/i2s_common.h"
+#include "driver/i2s_pdm.h"
+#include "driver/i2s_std.h"
+#include "driver/i2s_tdm.h"
+#include "driver/i2s_types.h"
 #include "driver/mcpwm_prelude.h"
 #else
 #include "driver/mcpwm.h"


### PR DESCRIPTION
In ESP-IDF 5.0, the I2S driver underwent a major rewrite. The new driver requires including a new set of header files. The old driver is still available (and is still included here and has bindings provided) but is deprecated and slated for removal.

This is required for the [I2S driver being written for esp-idf-hal](https://github.com/esp-rs/esp-idf-hal/issues/205).