### PR TITLE
Expose socket bindings when HTTP client is disbaled

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -130,6 +130,7 @@
 
 #ifdef ESP_IDF_COMP_LWIP_ENABLED
 #include "lwip/lwip_napt.h"
+#include "lwip/sockets.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
 #endif


### PR DESCRIPTION
Various socket related bindings are only exposed when the `esp_http_client` component is enabled. This PR adds the relevant header to the `lwip` component to remedy that.