### PR TITLE
build: avoid using custom cmake on esp-idf 5.x (where x < 4)

### DIFF
--- a/build/native/cargo_driver.rs
+++ b/build/native/cargo_driver.rs
@@ -60,7 +60,9 @@ pub fn build() -> Result<EspIdfBuildOutput> {
 
         // Use custom cmake for esp-idf<4.4, because we need at least cmake-3.20
         match version.as_ref().map(|v| (v.major, v.minor, v.patch)) {
-            Ok((major, minor, _)) if major >= 4 && minor >= 4 => subtools.push("cmake"),
+            Ok((major, minor, _)) if major > 4 || (major == 4 && minor >= 4) => {
+                subtools.push("cmake")
+            }
             _ => {
                 tools.push(espidf::Tools::cmake()?);
             }


### PR DESCRIPTION
The check for `>= 4.4` was incorrect and considered 5.0 to be before 4.4 (because the minor version was checked even for major versions greater than 4).

This resulted in us installing an older cmake version for esp-idf 5.0. This in turn resulted in builds on macos-arm64 failing (likely due to some separate bug) with the following error:

    Using esp-idf v5.0.1 at '/Users/jenkins/jenkins_root/workspace/p/_target/xtensa-esp32s3-espidf/debug/build/esp-idf-sys-875fc790415fd0c8/out/espressif/esp-idf-3e3d654f8a323aea/v5.0.1'
    ERROR: tool cmake does not have versions compatible with platform macos-arm64
    Error: Could not install esp-idf

    Caused by:
        command '"/Users/jenkins/jenkins_root/workspace/p/_target/xtensa-esp32s3-espidf/debug/build/esp-idf-sys-875fc790415fd0c8/out/espressif/python_env/idf5.0_py3.11_env/bin/python" "/Users/jenkins/jenkins_root/workspace/p/_target/xtensa-esp32s3-espidf/debug/build/esp-idf-sys-875fc790415fd0c8/out/espressif/esp-idf-3e3d654f8a323aea/v5.0.1/tools/idf_tools.py" "--idf-path" "/Users/jenkins/jenkins_root/workspace/p/_target/xtensa-esp32s3-espidf/debug/build/esp-idf-sys-875fc790415fd0c8/out/espressif/esp-idf-3e3d654f8a323aea/v5.0.1" "--tools-json" "/var/folders/4t/75n4m7md097bg_lqh_8q48nm0000gp/T/.tmpYdUkeX" "install" "cmake"' exited with non-zero status code 1

With this PR, the build of esp-idf-sys with esp-idf 5.0.1 works on the macos arm64 platform.