### PR TITLE
Generate bindings for lwip/netdb.h, esp_transport*.h

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -130,6 +130,7 @@
 
 #ifdef ESP_IDF_COMP_LWIP_ENABLED
 #include "lwip/lwip_napt.h"
+#include "lwip/netdb.h"
 #include "lwip/sockets.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
@@ -155,6 +156,13 @@
 
 #ifdef ESP_IDF_COMP_ESP_HTTP_CLIENT_ENABLED
 #include "esp_http_client.h"
+#endif
+
+#ifdef ESP_IDF_COMP_TCP_TRANSPORT_ENABLED
+#include "esp_transport.h"
+#include "esp_transport_ssl.h"
+#include "esp_transport_tcp.h"
+#include "esp_transport_ws.h"
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_HTTP_SERVER_ENABLED


### PR DESCRIPTION
When using the LwIP sockets API directly, one is likely to want to access lwip/netdb.h, as demonstrated by the examples in https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/api-guides/lwip.html#examples, so this branch includes that header file in bindings.h if ESP_IDF_COMP_LWIP_ENABLED.

As well, to use the tcp_transport component, it's necessary to include its header files, so this branch includes those files as well in bindings.h if ESP_IDF_COMP_TCP_TRANSPORT_ENABLED.