### PR TITLE
Fix - esp32c6 support as MCU

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -112,7 +112,7 @@ fn main() -> anyhow::Result<()> {
             .clang_args(build_output.components.clang_args())
             .clang_args(vec![
                 "-target",
-                if mcu == "esp32c3" {
+                if mcu == "esp32c3" || mcu == "esp32c6" {
                     // Necessary to pass explicitly, because of https://github.com/rust-lang/rust-bindgen/issues/1555
                     "riscv32"
                 } else {

--- a/build/native/cargo_driver/chip.rs
+++ b/build/native/cargo_driver/chip.rs
@@ -20,6 +20,9 @@ pub enum Chip {
     /// RISC-V based single core
     #[strum(serialize = "esp32c3")]
     ESP32C3,
+    /// RISC-V based single core
+    #[strum(serialize = "esp32c6")]
+    ESP32C6,
 }
 
 impl Chip {
@@ -33,7 +36,7 @@ impl Chip {
                 return Ok(Chip::ESP32);
             }
         } else if rust_target_triple.starts_with("riscv32imc-esp") {
-            return Ok(Chip::ESP32C3);
+            bail!("Multiple possible targets, please define MCU in .cargo/config.toml -> [ENV] section")
         }
         bail!("Unsupported target '{}'", rust_target_triple)
     }
@@ -45,6 +48,7 @@ impl Chip {
             Self::ESP32S2 => "xtensa-esp32s2-elf",
             Self::ESP32S3 => "xtensa-esp32s3-elf",
             Self::ESP32C3 => "riscv32-esp-elf",
+            Self::ESP32C6 => "riscv32-esp-elf",
         }
     }
 


### PR DESCRIPTION
Modified the chip and build to support the new MCU
1. Added support for MCU esp32c6
2. Disabled autodiscovery for Risc target