### PR TITLE
Add esp_rom_crc.h to bindings

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -4,7 +4,7 @@
 #error Only ESP-IDF versions >= V4.3.2 are currently supported; if you are using the PIO build (the default one), wipe out your `.embuild` folder and try again with a clean rebuild
 #endif
 
-//#include "esp_crc.h"
+#include "esp_rom_crc.h"
 #include "esp_log.h"
 #include "esp_debug_helpers.h"
 


### PR DESCRIPTION
@ivmarkov mentioned they do not remember why the `esp_crc.h` header was removed, but I suspect it may have to do with it now being part of the [esp_rom component](https://github.com/espressif/esp-idf/tree/master/components/esp_rom). Some ROM functions are only available on certain chips, but the extracted ones like `esp_rom_crc.h` **"are expected to exist across all chips. If some of them are missed in the new chips, we will implement them again in `esp_rom/patches`."**

More headers from `esp_rom` could be included, but I'll take it one step at a time and start with CRC because I need it. I wrote working sample code that uses this [at my repository](https://github.com/jordanhalase/test-esp-idf-sys-crc/blob/master/src/main.rs).

```rust
use esp_idf_sys::*;

const CRC_INITIAL: u32 = 0xffffffff;

#[inline(always)]
pub fn crc32_be(crc: u32, buf: &[u8]) -> u32 {
    unsafe { esp_rom_crc32_be(crc, buf.as_ptr(), buf.len() as u32) }
}

fn main() -> ! {
    esp_idf_sys::link_patches();

    let crc_check = "123456789";

    loop {
        // Perform CRC-32/MPEG-2
        // width=32 poly=0x04c11db7 init=0xffffffff refin=false refout=false xorout=0x00000000 check=0x0376e6e7 residue=0x00000000 name="CRC-32/MPEG-2"
        let crc = !crc32_be(!CRC_INITIAL, crc_check.as_bytes());

        println!("CRC is {:08x}", crc);
        assert_eq!(crc, 0x0376e6e7);

        std::thread::sleep(std::time::Duration::from_secs(2));
    }
}
```

resolves #169 