### PR TITLE
Allow I2S builds on v4.4.

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -212,6 +212,7 @@
 #include "driver/i2s_types.h"
 #include "driver/mcpwm_prelude.h"
 #else
+#include "driver/i2s.h"
 #include "driver/mcpwm.h"
 #endif
 #ifndef CONFIG_IDF_TARGET_ESP32C3


### PR DESCRIPTION
This change includes the I2S headers for ESP-IDF v4.4, allowing the Rust I2S driver being considered in this pull request to build on that version of ESP-IDF.

https://github.com/esp-rs/esp-idf-hal/pull/232