### PR TITLE
Add note about CARGO_TARGET_DIR requiring CARGO_WORKSPACE_DIR

### DIFF
--- a/BUILD_OPTIONS.md
+++ b/BUILD_OPTIONS.md
@@ -93,6 +93,15 @@ There are two ways to configure how the ESP-IDF framework is compiled:
 > There is no need to explicitly add a 
 > [`[workspace]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section)
 > section to the `Cargo.toml` of the workspace directory.
+>
+> Please note that if you have set `CARGO_TARGET_DIR` and moved your `target` directory out of
+> the crate root, then embuild is not able to locate the crate root. This will result in it
+> among other things ignoring your local `sdkconfig.defaults`. In this setup you must declare:
+> ```
+> [env]
+> CARGO_WORKSPACE_DIR = { value = "", relative = true }
+> ```
+> to force it to look in the current directory.
        
 
 The following configuration options are available:


### PR DESCRIPTION
My `sdkconfig.defaults` file is always ignored. And it takes so much time before I figure out why. I never have `CARGO_TARGET_DIR` unset, because I don't want to fill up my source code folders with build artifacts. This `embuild` caveat is poorly documented. It would be great if the `esp-idf-sys` documentation would mention it.

I would add a link to a reference on why this is needed if I had one. But I can't remember where I learned about this workaround. I learned about it a long time ago but then I forget about it every time I pick up esp programming.