### PR TITLE
Provide PCNT v5 bindings.

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -109,6 +109,7 @@ fn main() -> anyhow::Result<()> {
             .blocklist_function("_v.*printf_r")
             .blocklist_function("_v.*scanf_r")
             .blocklist_function("esp_log_writev")
+            .blocklist_type("pcnt_unit_t") // Fix for struct pcnt_unit_t vs enum pcnt_unit_t
             .clang_args(build_output.components.clang_args())
             .clang_args(vec![
                 "-target",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -231,6 +231,9 @@
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32P4)
 #include "driver/pcnt.h"
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "driver/pulse_cnt.h"
+#endif
 #endif
 #include "driver/periph_ctrl.h"
 #include "driver/rmt.h"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,14 @@ pub fn link_patches() -> PatchesRef {
 #[allow(rustdoc::all)]
 #[allow(improper_ctypes)] // TODO: For now, as 5.0 spits out tons of these
 mod bindings {
+    // The following is defined to remove a case where bindgen can't handle pcnt_unit_t being defined
+    // in two different C namespaces (enum vs struct). The struct is opaque (used only as a pointer to an
+    // opaque type via pcnt_channel_handle_t), so we use the enum definition here, taken from the v4
+    // bindgen.
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32h2, esp32c6, esp32p4))]
+    /// Selection of all available PCNT units
+    #[allow(non_camel_case_types)]
+    pub type pcnt_unit_t = core::ffi::c_int;
+
     include!(env!("EMBUILD_GENERATED_BINDINGS_FILE"));
 }


### PR DESCRIPTION
This provides bindings for the PCNT peripheral using the ESP-IDF v5+ definitions in conjunction with the ESP-IDF v4 definitions. It removes a case where bindgen can't cope with a typename that exists in two namespaces (`enum pcnt_unit_t` in v4, `struct pcnt_unit_t` in v5) by manually handling this special case.

This is a different take on the problem than https://github.com/esp-rs/esp-idf-sys/pull/156 and should allow esp-idf-hal to continue to run peacefully (and punts the porting problem there into the future).