### PR TITLE
PCNT v5 bindings take 2

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -109,6 +109,7 @@ fn main() -> anyhow::Result<()> {
             .blocklist_function("_v.*printf_r")
             .blocklist_function("_v.*scanf_r")
             .blocklist_function("esp_log_writev")
+            .blocklist_type("pcnt_unit_t") // Fix for struct pcnt_unit_t vs enum pcnt_unit_t
             .clang_args(build_output.components.clang_args())
             .clang_args(vec![
                 "-target",

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -231,6 +231,9 @@
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32H2) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32P4)
 #include "driver/pcnt.h"
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "driver/pulse_cnt.h"
+#endif
 #endif
 #include "driver/periph_ctrl.h"
 #include "driver/rmt.h"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,14 @@ pub fn link_patches() -> PatchesRef {
 #[allow(rustdoc::all)]
 #[allow(improper_ctypes)] // TODO: For now, as 5.0 spits out tons of these
 mod bindings {
+    // The following is defined to remove a case where bindgen can't handle pcnt_unit_t being defined
+    // in two different C namespaces (enum vs struct). The struct is opaque (used only as a pointer to an
+    // opaque type via pcnt_channel_handle_t), so we use the enum definition here, taken from the v4
+    // bindgen.
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32h2, esp32c6, esp32p4))]
+    /// Selection of all available PCNT units
+    #[allow(non_camel_case_types)]
+    pub type pcnt_unit_t = core::ffi::c_int;
+
     include!(env!("EMBUILD_GENERATED_BINDINGS_FILE"));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@
 pub use bindings::*;
 pub use error::*;
 
+// Don't use esp_idf_soc_pcnt_supported; that's only on ESP-IDF v5.x+.
+#[cfg(any(esp32, esp32s2, esp32s3, esp32c6, esp32h2))]
+pub use pcnt::*;
+
 #[doc(hidden)]
 pub use build_time;
 #[doc(hidden)]
@@ -19,6 +23,9 @@ mod app_desc;
 mod error;
 mod panic;
 mod patches;
+#[cfg(any(esp32, esp32s2, esp32s3, esp32c6, esp32h2))]
+mod pcnt;
+
 mod start;
 
 /// If any of the two constants below do not compile, you have not properly setup the rustc cfg flag `espidf_time64`:
@@ -52,14 +59,8 @@ pub fn link_patches() -> PatchesRef {
 #[allow(rustdoc::all)]
 #[allow(improper_ctypes)] // TODO: For now, as 5.0 spits out tons of these
 mod bindings {
-    // The following is defined to remove a case where bindgen can't handle pcnt_unit_t being defined
-    // in two different C namespaces (enum vs struct). The struct is opaque (used only as a pointer to an
-    // opaque type via pcnt_channel_handle_t), so we use the enum definition here, taken from the v4
-    // bindgen.
-    #[cfg(any(esp32, esp32s2, esp32s3, esp32h2, esp32c6, esp32p4))]
-    /// Selection of all available PCNT units
-    #[allow(non_camel_case_types)]
-    pub type pcnt_unit_t = core::ffi::c_int;
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c6, esp32h2))]
+    use crate::pcnt::*;
 
     include!(env!("EMBUILD_GENERATED_BINDINGS_FILE"));
 }

--- a/src/pcnt.rs
+++ b/src/pcnt.rs
@@ -1,0 +1,52 @@
+#![allow(non_camel_case_types, non_upper_case_globals)]
+
+// The following is defined to remove a case where bindgen can't handle pcnt_unit_t being defined
+// in two different C namespaces (enum vs struct). The struct is opaque (used only as a pointer to an
+// opaque type via pcnt_channel_handle_t), so we use the enum definition here, taken from the v4
+// bindgen.
+
+/// Selection of all available PCNT units
+pub type pcnt_unit_t = core::ffi::c_int;
+
+/// PCNT unit 0
+pub const pcnt_unit_t_PCNT_UNIT_0: pcnt_unit_t = 0;
+
+/// PCNT unit 1
+pub const pcnt_unit_t_PCNT_UNIT_1: pcnt_unit_t = 1;
+
+/// PCNT unit 2
+pub const pcnt_unit_t_PCNT_UNIT_2: pcnt_unit_t = 2;
+
+/// PCNT unit 3
+pub const pcnt_unit_t_PCNT_UNIT_3: pcnt_unit_t = 3;
+
+// Ideally, we'd use a conditional off of SOC_PCNT_UNITS_PER_GROUP, but that's not possible in Rust.
+// Today, ESP32 is the only chip that has 8 units. All others have 4 (except ESP32-C3, which doesn't
+// have PCNT at all). For new chips, check $IDF_PATH/components/soc/$CHIP/include/soc/soc_caps.h for
+// for the value of SOC_PCNT_UNITS_PER_GROUP.
+
+#[cfg(esp32)]
+/// PCNT unit 4
+pub const pcnt_unit_t_PCNT_UNIT_4: pcnt_unit_t = 4;
+
+#[cfg(esp32)]
+/// PCNT unit 5
+pub const pcnt_unit_t_PCNT_UNIT_5: pcnt_unit_t = 5;
+
+#[cfg(esp32)]
+/// PCNT unit 6
+pub const pcnt_unit_t_PCNT_UNIT_6: pcnt_unit_t = 6;
+
+#[cfg(esp32)]
+/// PCNT unit 7
+pub const pcnt_unit_t_PCNT_UNIT_7: pcnt_unit_t = 7;
+
+// For some reason, this isn't defined in soc_caps.h for ESP32-H2 on ESP-IDF v4.x
+
+/// Maximum number of PCNT units
+#[cfg(not(all(esp32h2, esp_idf_version_major = "4")))]
+pub const pcnt_unit_t_PCNT_UNIT_MAX: pcnt_unit_t = crate::SOC_PCNT_UNITS_PER_GROUP as pcnt_unit_t;
+
+/// Maximum number of PCNT units
+#[cfg(all(esp32h2, esp_idf_version_major = "4"))]
+pub const pcnt_unit_t_PCNT_UNIT_MAX: pcnt_unit_t = 4;


### PR DESCRIPTION
Re-do of https://github.com/esp-rs/esp-idf-sys/pull/229

This provides bindings for the PCNT peripheral using the ESP-IDF v5+ definitions in conjunction with the ESP-IDF v4 definitions. It removes a case where bindgen can't cope with a typename that exists in two namespaces (enum pcnt_unit_t in v4, struct pcnt_unit_t in v5) by manually handling this special case.

This is a different take on the problem than https://github.com/esp-rs/esp-idf-sys/pull/156 and should allow esp-idf-hal to continue to run peacefully (and punts the porting problem there into the future).

Tested this time against actual targets that *have* PCNT peripherals.