### PR TITLE
Generate bindings for esp_freertos_hooks.h

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -14,6 +14,7 @@
 #include "esp_interface.h"
 #include "esp_ipc.h"
 #include "esp_mac.h"
+#include "esp_freertos_hooks.h"
 
 #include "freertos/task_snapshot.h"
 


### PR DESCRIPTION
This wasn't bound before and as far as I can see, it doesn't need any specific config to be set in order to be available.