### PR TITLE
include new ADC api

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -67,6 +67,10 @@
 
 #if defined(ESP_IDF_COMP_ESP_ADC_CAL_ENABLED) || defined(ESP_IDF_COMP_ESP_ADC_ENABLED)
 #include "esp_adc_cal.h"
+#if ESP_IDF_VERSION_MAJOR > 4
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+#endif
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_EVENT_ENABLED
@@ -207,6 +211,9 @@
 #endif
 
 #ifdef ESP_IDF_COMP_DRIVER_ENABLED
+#if ESP_IDF_VERSION_MAJOR > 4
+#include "esp_adc/adc_oneshot.h"
+#endif
 #include "driver/adc.h"
 #if ESP_IDF_VERSION_MAJOR > 4
 #include "esp_adc/adc_continuous.h"

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -211,11 +211,9 @@
 #endif
 
 #ifdef ESP_IDF_COMP_DRIVER_ENABLED
-#if ESP_IDF_VERSION_MAJOR > 4
-#include "esp_adc/adc_oneshot.h"
-#endif
 #include "driver/adc.h"
 #if ESP_IDF_VERSION_MAJOR > 4
+#include "esp_adc/adc_oneshot.h"
 #include "esp_adc/adc_continuous.h"
 #endif
 #include "driver/twai.h"


### PR DESCRIPTION
Including the new ADC api headers.  This makes ADC calibration available for esp32c6 wgen using esp-idf >= 5.1.1 and the new api available for esp-idf >= 5.0.0.