### PR TITLE
build/config.rs: non-native build fix

### DIFF
--- a/build/config.rs
+++ b/build/config.rs
@@ -126,6 +126,7 @@ impl BuildConfig {
                     esp_idf_sdkconfig,
                     esp_idf_sdkconfig_defaults,
                     mcu,
+                    #[cfg(feature = "native")]
                     native: _,
                     esp_idf_sys_root_crate: _,
                 },


### PR DESCRIPTION
I got an error when i tried to build without the "native" feature active:

```
error[E0026]: struct `BuildConfig` does not have a field named `native`
   --> esp-idf-sys/build/config.rs:129:21
    |
129 |                     native: _,
    |                     ^^^^^^ struct `BuildConfig` does not have this field

For more information about this error, try `rustc --explain E0026`.
error: could not compile `esp-idf-sys` (build script) due to previous error
```

For completeness sake, I thought this might have been interesting for you upstream.