### PR TITLE
Fix Windows Path Length Typo

### DIFF
--- a/build/common.rs
+++ b/build/common.rs
@@ -438,7 +438,7 @@ pub fn sanitize_project_path() -> Result<()> {
     #[cfg(windows)]
     {
         if out_dir.len() > 86 {
-            report(format!("Too long output directory: `{out_dir}`. Shorten your project path down to no more than 10 characters (or use WSL2 and its native Linux filesystem). Note that tricks like Windows `subst` do NOT work!"))?;
+            report(format!("Too long output directory: `{out_dir}`. Shorten your project path down to no more than 90 characters (or use WSL2 and its native Linux filesystem). Note that tricks like Windows `subst` do NOT work!"))?;
         }
     }
 


### PR DESCRIPTION
Looks like there was a typo in the error message displayed when path was too long under windows.