### PR TITLE
Fix compile error for esp32c6 with NimBLE.

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -398,7 +398,9 @@
 
 // Nimble APIs (BLE only)
 #ifdef CONFIG_BT_NIMBLE_ENABLED
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
 #include "esp_nimble_hci.h"
+#endif
 #include "nimble/nimble_port.h"
 #include "nimble/nimble_port_freertos.h"
 #include "host/ble_hs.h"


### PR DESCRIPTION
The following error occurs when compiling for esp32c6 with NimBLE enabled.
```
  Caused by:
      clang diagnosed error: /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-sys-0.33.3/src/include/esp-idf/bindings.h:401:10: fatal error: 'esp_nimble_hci.h' file not found
```

The file 'esp_nimble_hci.h' seems to be used only for esp32, esp32s3, and esp32c3.

refer to:
- https://github.com/espressif/esp-idf/blob/8fc8f3f47997aadba21facabc66004c1d22de181/components/bt/host/nimble/Kconfig.in#L667
- https://github.com/espressif/esp-idf/blob/8fc8f3f47997aadba21facabc66004c1d22de181/components/bt/CMakeLists.txt#L664