### PR TITLE
Export `esp_netif_sntp` APIs from esp-idf 5.1

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -153,8 +153,10 @@
 #include "lwip/sockets.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
+#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif_sntp.h"
+#endif
 #endif
 #endif
 

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -106,9 +106,9 @@
 #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1
 #include "esp_supplicant_utils.h"
 #endif
-//#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 2
-//#include "esp_eap_client.h"
-//#endif
+// #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 2
+// #include "esp_eap_client.h"
+// #endif
 #endif
 
 #ifdef ESP_IDF_COMP_ESP_ETH_ENABLED
@@ -153,6 +153,9 @@
 #include "lwip/sockets.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
+#ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
+#include "esp_netif_sntp.h"
+#endif
 #endif
 
 #ifdef ESP_IDF_COMP_MBEDTLS_ENABLED


### PR DESCRIPTION
https://docs.espressif.com/projects/esp-idf/en/v5.1.1/esp32/migration-guides/release-5.x/5.1/networking.html