### PR TITLE
👽️ include gptimer headers

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -240,6 +240,9 @@
 #include "driver/dac.h"
 #endif
 #include "driver/gpio.h"
+#if ESP_IDF_VERSION_MAJOR > 4
+#include "driver/gptimer.h"
+#endif
 #include "driver/i2c.h"
 #include "driver/i2s.h"
 #include "driver/ledc.h"


### PR DESCRIPTION
ESP-IDF 5 introduced a new timer api and made the old one "deprecated". This change make it available for consumers of esp-idf-sys. 

This variant to just expose it for all versions greater > 4 is the simplest of all but comes with the following potential problems: 
 - Hard fault when used with "driver/timer.h" at the same time at runtime(esp-idf made sure at runtime that only one of both is used). This is not a problem for compiling or linking, it is only a potential thing for user that uses esp-idf-sys directly.
 
Unfortunately esp-idf doesn't expose a good kconfig variable, to  selectively import the headers based on it. If we are desperate we could hack into the "GPTIMER_SUPPRESS_DEPRECATE_WARN" kconfig, if the user set this in his sdkconfig file we would only compile the new one and if its unset it would use the old api. Since this is really hacky i suppose we should just go with the first option for now. 

My driver downstream in (esp-idf-hal) will be feature gated for now, and if activated, will disable the old driver completely. Though it would be nicer if we could get that info from upstream. 