### PR TITLE
Add temperature sensor header for ESP32C3

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -297,6 +297,10 @@
 #include "driver/uart_select.h"
 #endif
 
+#if ESP_IDF_VERSION_MAJOR > 4 && defined(SOC_TEMP_SENSOR_SUPPORTED)
+#include "driver/temperature_sensor.h"
+#endif
+
 #ifdef ESP_IDF_COMP_ESPCOREDUMP_ENABLED
 #include "esp_core_dump.h"
 #endif


### PR DESCRIPTION
Prerequisite for getting the internal temperature sensor in various ESP32 chips working.

Also see this issue over in esp-idf-hal: https://github.com/esp-rs/esp-idf-hal/issues/333