### PR TITLE
stop cargo metadata from downloading rust crates not needed for the host platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ embuild = { version = "0.31.3", features = ["glob", "kconfig"] }
 anyhow = "1"
 regex = "1.5"
 bindgen = "0.63"
-cargo_metadata = "0.15"
+cargo_metadata = "0.18"
 serde = { version = "1.0", features = ["derive"] }
 strum = { version = "0.24", features = ["derive"] }
 envy = "0.4.2"

--- a/build/config.rs
+++ b/build/config.rs
@@ -104,7 +104,7 @@ impl BuildConfig {
     /// [root crate]: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
     pub fn with_cargo_metadata(&mut self) -> Result<()> {
         // workaround for https://github.com/esp-rs/esp-idf-sys/issues/260
-        let current_target = std::env::var("TARGET").unwrap();
+        let current_target = std::env::var("TARGET")?;
         let filter_string = format!("--filter-platform={}", current_target);
 
         let metadata = cargo_metadata::MetadataCommand::new()

--- a/build/config.rs
+++ b/build/config.rs
@@ -103,9 +103,13 @@ impl BuildConfig {
     ///
     /// [root crate]: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
     pub fn with_cargo_metadata(&mut self) -> Result<()> {
+        // workaround for https://github.com/esp-rs/esp-idf-sys/issues/260
+        let current_target = std::env::var("TARGET").unwrap();
+        let filter_string = format!("--filter-platform={}", current_target);
+
         let metadata = cargo_metadata::MetadataCommand::new()
             .current_dir(workspace_dir()?)
-            .other_options(vec!["--locked".into()])
+            .other_options(vec!["--locked".into(), filter_string])
             .exec()?;
 
         let root_package = match (metadata.root_package(), &self.esp_idf_sys_root_crate) {


### PR DESCRIPTION
cargo metadata unfortunately by default runs in some mode where it always run for "all targets". In our case it will download all windows specific crates on all platform targets, even if they are never used. This cost a lot of space for nothing. 

I first bumped up the version of the cargo_metadata crate and now added a flag that should prevent this behavior. I tested it inside a new environment with this patch and it seams to work.  

This PR fix: #260 