### PR TITLE
Export LCD bindings for ESP32-S3

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -441,3 +441,18 @@
 #endif // CONFIG_BT_ENABLED
 
 #endif // CONFIG_IDF_TARGET_ESP32S2
+
+//LCD support
+#if ((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)) || (ESP_IDF_VERSION_MAJOR >= 5)
+#ifdef ESP_IDF_COMP_ESP_LCD_ENABLED
+#include "esp_lcd_types.h"
+#include "esp_lcd_panel_rgb.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_panel_commands.h"
+#include "esp_lcd_panel_interface.h"
+#include "esp_lcd_panel_io_interface.h"
+#endif //ESP_IDF_COMP_LCD_ENABLED
+#endif //((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4) || (ESP_IDF_VERSION_MAJOR >= 5))
+


### PR DESCRIPTION
This introduces the LCD bindings for the ESP32-S3, as suggested in #216.