### PR TITLE
Added support for v5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: "50 4 * * *"
+    - cron: "50 6 * * *"
   workflow_dispatch:
 
 env:
-  rust_nightly_toolchain: nightly
+  rust_toolchain: nightly
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -18,13 +18,16 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         target:
           - riscv32imc-esp-espidf
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
+        idf-version:
+          - v4.4.6
+          - v5.1.2
+          - v5.2
 
     steps:
       - name: Setup | Checkout
@@ -34,41 +37,52 @@ jobs:
         if: matrix.target == 'riscv32imc-esp-espidf'
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ env.rust_nightly_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
           components: rustfmt, clippy, rust-src
 
       - name: Install Rust for Xtensa
         if: matrix.target != 'riscv32imc-esp-espidf'
-        uses: esp-rs/xtensa-toolchain@v1.5.0
+        uses: esp-rs/xtensa-toolchain@v1.5.1
         with:
           default: true
 
       - name: Build | Fmt Check
         run: cargo fmt -- --check
 
-      - name: Build | Clippy (PIO)
-        if: matrix.target == 'riscv32imc-esp-espidf'
+      - name: Build | Clippy
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-        run: cargo clippy --features pio --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo clippy --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
 
-      - name: Build | Compile (Native) / ESP-IDF V4.4
+      - name: Build | Compile
         env:
-          RUSTFLAGS: ""
-          ESP_IDF_VERSION: release/v4.4
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
         run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
-      - name: Build | Compile (Native) / ESP-IDF V5.0
+      - name: Build | Compile, no_std
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-          ESP_IDF_VERSION: release/v5.0
-        run: cargo clean; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo build --no-default-features --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
-      - name: Build | Compile (Native) / ESP-IDF V5.1
+      - name: Build | Compile, default-features
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-          ESP_IDF_VERSION: release/v5.1
-        run: cargo clean; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+
+      - name: Build | Compile
+        env:
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo build --no-default-features --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
       - name: Setup | ldproxy
         if: matrix.target == 'riscv32imc-esp-espidf'
@@ -79,7 +93,7 @@ jobs:
 
       - name: Build | Examples
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          ESP_IDF_VERSION: release/v5.1
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
         run: cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort


### PR DESCRIPTION
When implementing support for the newest v5.2 release from espressif, I found https://github.com/espressif/esp-idf/issues/13113 this issue, where they mention we need to apply a patch, or the linker is going to run havoc.

Also, updated the pipeline so it looks more similar to the esp-idf-svc pipeline. This MR is required for https://github.com/esp-rs/esp-idf-svc/pull/365, else that one can't build.