### PR TITLE
use new esp-idf 5.1 DAC bindings

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -265,9 +265,18 @@
 #include "esp_adc/adc_continuous.h"
 #endif
 #include "driver/twai.h"
+
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
+#if ESP_IDF_VERSION_MAJOR > 5 ||                                               \
+    ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1
+#include "driver/dac_continuous.h"
+#include "driver/dac_cosine.h"
+#include "driver/dac_oneshot.h"
+#else
 #include "driver/dac.h"
 #endif
+#endif
+
 #include "driver/gpio.h"
 #if ESP_IDF_VERSION_MAJOR > 4
 #include "driver/gptimer.h"


### PR DESCRIPTION
This follows the migration recommended in the [5.1 release notes](https://github.com/espressif/esp-idf/blob/release/v5.1/docs/en/migration-guides/release-5.x/5.1/peripherals.rst).