### PR TITLE
Add new i2c includes for idf 5.2

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -276,9 +276,8 @@
 #include "driver/i2c_types.h"
 #include "driver/i2c_master.h"
 #include "driver/i2c_slave.h"
-#else
-#include "driver/i2c.h"
 #endif
+#include "driver/i2c.h"
 #include "driver/i2s.h"
 #include "driver/ledc.h"
 #if ESP_IDF_VERSION_MAJOR > 4

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -272,7 +272,13 @@
 #if ESP_IDF_VERSION_MAJOR > 4
 #include "driver/gptimer.h"
 #endif
+#if ESP_IDF_VERSION_MAJOR > 5 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR > 1)
+#include "driver/i2c_types.h"
+#include "driver/i2c_master.h"
+#include "driver/i2c_slave.h"
+#else
 #include "driver/i2c.h"
+#endif
 #include "driver/i2s.h"
 #include "driver/ledc.h"
 #if ESP_IDF_VERSION_MAJOR > 4
@@ -466,7 +472,7 @@
 
 #endif // CONFIG_IDF_TARGET_ESP32S2
 
-//LCD support
+// LCD support
 #if ((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4)) || (ESP_IDF_VERSION_MAJOR >= 5)
 #ifdef ESP_IDF_COMP_ESP_LCD_ENABLED
 #include "esp_lcd_types.h"
@@ -477,6 +483,5 @@
 #include "esp_lcd_panel_commands.h"
 #include "esp_lcd_panel_interface.h"
 #include "esp_lcd_panel_io_interface.h"
-#endif //ESP_IDF_COMP_LCD_ENABLED
+#endif // ESP_IDF_COMP_LCD_ENABLED
 #endif //((ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR >= 4) || (ESP_IDF_VERSION_MAJOR >= 5))
-


### PR DESCRIPTION
## Challenges

- new implementation of `i2c` does not expose commands interface, so the `transaction` function in the `esp-idf-hal` couldn't be used anymore. 
  1. Now is the question to keep the legacy implementations for a `I2CDriver` implementation with the transaction interface. This will lead to `#include hal/i2c_types.h` because the legacy header exposes types from the hal. The new `i2c` implementation could be used for an extra `I2CBusDriver`.
  2. The other solution would be to request a public interface to a transactional operation in the new `i2c` implementation in `esp-idf`.