### PR TITLE
Custom debug for EspError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use crate::{esp_err_t, esp_err_to_name, ESP_OK};
 /// An [`esp_err_t`] is returned from most esp-idf APIs as a status code. If it is equal
 /// to [`ESP_OK`] it means **no** error occurred.
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct EspError(NonZeroI32);
 
 const _: () = if ESP_OK != 0 {
@@ -79,8 +79,14 @@ impl fmt::Display for EspError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unsafe {
             let s = ffi::CStr::from_ptr(esp_err_to_name(self.code()));
-            str::from_utf8_unchecked(s.to_bytes()).fmt(f)
+            core::fmt::Display::fmt(&str::from_utf8_unchecked(s.to_bytes()), f)
         }
+    }
+}
+
+impl fmt::Debug for EspError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (error code {})", self, self.code())
     }
 }
 


### PR DESCRIPTION
Hello,
This pull request explicitly implements Debug for EspError, so the human readable error string is shown instead of the error number inside the struct

This doesn't seem to have a negative impact, instead, in my application it seems to **reduce** code size

with this pr:
`App/part. size:    846,240/8,323,072 bytes, 10.17%`

with the original code:
`App/part. size:    848,720/8,323,072 bytes, 10.20%`

So 3 flash pages are freed with this modification

this pr:
```
called `Result::unwrap()` on an `Err` value: ESP_ERR_ESPNOW_NOT_FOUND (error code 12393)
```
original code:
```
called `Result::unwrap()` on an `Err` value: EspError(12393)
```

