### PR TITLE
⬆️ update bindgen to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ const_format = "0.2" # For esp_app_desc!()
 embuild = { version = "0.31.3", features = ["glob", "kconfig", "cmake", "espidf"] }
 anyhow = "1"
 regex = "1.5"
-bindgen = "0.63"
+bindgen = "0.69"
 cargo_metadata = "0.18"
 serde = { version = "1.0", features = ["derive"] }
 strum = { version = "0.24", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ which = "4.4"
 
 
 [patch.crates-io]
-embuild ={ git = "https://github.com/Vollbrecht/embuild", branch = "develop"}
+embuild ={ git = "https://github.com/esp-rs/embuild"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 strum = { version = "0.24", features = ["derive"] }
 envy = "0.4.2"
 which = "4.4"
+
+
+[patch.crates-io]
+embuild ={ git = "https://github.com/Vollbrecht/embuild", branch = "develop"}


### PR DESCRIPTION
The changelog of bindgen added a lot between 0.63 and 0.69 though it still seams to work without any problems. They introduces some new features that may be interesting in the future - like creating bindgens for C functions that are inlined in the api and thus currently not producing any bindgen output etc. 

This change is also needed when https://github.com/esp-rs/embuild/pull/85 lands so we have version parity between both