### PR TITLE
CI: Parallelize the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  rust_nightly_toolchain: nightly
+  rust_toolchain: nightly
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -25,7 +25,10 @@ jobs:
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
-
+        idf-version:
+          - v4.4.6
+          - v5.1.2
+          - v5.2
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v3
@@ -34,41 +37,48 @@ jobs:
         if: matrix.target == 'riscv32imc-esp-espidf'
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: ${{ env.rust_nightly_toolchain }}
+          toolchain: ${{ env.rust_toolchain }}
           components: rustfmt, clippy, rust-src
 
       - name: Install Rust for Xtensa
         if: matrix.target != 'riscv32imc-esp-espidf'
-        uses: esp-rs/xtensa-toolchain@v1.5.0
+        uses: esp-rs/xtensa-toolchain@v1.5.1
         with:
           default: true
 
       - name: Build | Fmt Check
         run: cargo fmt -- --check
 
-      - name: Build | Clippy (PIO)
-        if: matrix.target == 'riscv32imc-esp-espidf'
-        env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-        run: cargo clippy --features pio --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
+#      - name: Build | Clippy (PIO)
+#        if: matrix.target == 'riscv32imc-esp-espidf' && matrix.idf-version == 'v5.2.1'
+#        env:
+#          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
+#        run: cargo clippy --features pio --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
 
-      - name: Build | Compile (Native) / ESP-IDF V4.4
+      - name: Build | Clippy
         env:
-          RUSTFLAGS: ""
-          ESP_IDF_VERSION: release/v4.4
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo clippy --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings -Adeprecated
+
+      - name: Build | Compile (Native)
+        env:
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
         run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
-      - name: Build | Compile (Native) / ESP-IDF V5.0
+      - name: Build | Compile (Native), no_std
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-          ESP_IDF_VERSION: release/v5.0
-        run: cargo clean; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+        run: cargo build --target ${{ matrix.target }} --no-default-features -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
-      - name: Build | Compile (Native) / ESP-IDF V5.1
-        env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-          ESP_IDF_VERSION: release/v5.1
-        run: cargo clean; cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+#      - name: Build | Compile (Native), alloc
+#        env:
+#          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+#          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
+#        run: cargo build --no-default-features --features alloc --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
       - name: Setup | ldproxy
         if: matrix.target == 'riscv32imc-esp-espidf'
@@ -79,7 +89,6 @@ jobs:
 
       - name: Build | Examples
         env:
-          RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
-          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          ESP_IDF_VERSION: release/v5.1
+          ESP_IDF_VERSION: ${{ matrix.idf-version }}
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' || '' }}"
         run: cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort


### PR DESCRIPTION
As discussed on Matrix, this PR is parallelizing the build of `sys` against the various ESP IDF versions. For now, I've excluded the PIO build from CI so that we get comparable figures.

(One thing svc has which sys doesn't is a lot of examples, so svc will spend much more time in linking, but we'll see).