### PR TITLE
Adding usb-serial

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -508,4 +508,9 @@
 #endif // (ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 3
 #endif // ESP_IDF_COMP_LCD_ENABLED
 
+// usb serial support
+#if ESP_IDF_VERSION_MAJOR > 4 && defined(SOC_USB_SERIAL_JTAG_SUPPORTED)
+#include "driver/usb_serial_jtag.h"
+#endif
+
 // n

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -509,7 +509,7 @@
 #endif // ESP_IDF_COMP_LCD_ENABLED
 
 // usb serial support
-#if ESP_IDF_VERSION_MAJOR > 4 && defined(SOC_USB_SERIAL_JTAG_SUPPORTED)
+#ifdef SOC_USB_SERIAL_JTAG_SUPPORTED
 #include "driver/usb_serial_jtag.h"
 #endif
 


### PR DESCRIPTION
This PR allow to use `usb_serial_jtag_driver_install` function and to set USB Serial to blocking mode on esp32-c3, which could be useful for reading from stdin