### PR TITLE
Explicitly include the FATFS API for 4.4.x

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -163,6 +163,7 @@
 #include "diskio_rawflash.h"
 #include "diskio_sdmmc.h"
 #include "diskio_wl.h"
+#include "ff.h"
 #endif
 
 #endif


### PR DESCRIPTION
Subject says it all. The FATFS library API is not available by default with ESP IDF 4.4.x