### PR TITLE
Add raw bindings to the internal DNS resolver API

### DIFF
--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -187,6 +187,7 @@
 #endif
 
 #ifdef ESP_IDF_COMP_LWIP_ENABLED
+#include "lwip/dns.h"
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"


### PR DESCRIPTION
I am using dns_gethostbyname_addrtype to do parallel resolution of IPv4 and IPv6 addresses with async callbacks in my project.

Adding this header file would help me greatly.