### PR TITLE
build cargo_driver: update embuild to support non-git `IDF_PATH`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ build-time = "0.1"   # For esp_app_desc!()
 const_format = "0.2" # For esp_app_desc!()
 
 [build-dependencies]
-embuild = { version = "0.32", features = ["glob", "kconfig", "cmake", "espidf"] }
+embuild = { git = "https://github.com/denbeigh2000/embuild", rev = "be687ce7dc78fd4cba6f0defd513e0ebb32aac73", version = "0.32", features = ["glob", "kconfig", "cmake", "espidf"] }
 anyhow = "1"
 regex = "1.5"
 bindgen = "0.69"

--- a/build/common.rs
+++ b/build/common.rs
@@ -257,8 +257,7 @@ impl InstallDir {
     /// Get the install directory from the [`ESP_IDF_TOOLS_INSTALL_DIR_VAR`] env variable.
     ///
     /// If this env variable is unset or empty uses `default_install_dir` instead.
-    /// On success returns `(install_dir as InstallDir, is_default as bool)`.
-    pub fn try_from(location: Option<&str>) -> Result<InstallDir> {
+    pub fn try_from(location: Option<&str>) -> Result<Self> {
         let (location, path) = match &location {
             None => (crate::config::DEFAULT_TOOLS_INSTALL_DIR, None),
             Some(val) => {


### PR DESCRIPTION
Updates the version of `embuild`, and the way it gets invoked, so that we can make use of the changes in https://github.com/esp-rs/embuild/pull/95.

This will allow the end user to provide an `IDF_PATH` that is not a git checkout.

See [this comment](https://github.com/esp-rs/embuild/pull/95#issuecomment-2510228806) for testing methodology

Closes #241.
Not sure about #184, but it will at least remove some blockers to that end.

cc/ @ivmarkov

See also:
- https://github.com/esp-rs/embuild/issues/81#issuecomment-2496600999
- https://github.com/esp-rs/embuild/pull/95 