### PR TITLE
Expose bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Deprecated
+
+### Breaking
+
+### Added
+- Add raw bindings for `esp_netif_net_stack.h` and `lwip/esp_netif_net_stack.h`. (#360)
+
+### Fixed
+
 ## [0.36.0] - 2025-01-02
 
 ### Deprecated

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -100,8 +100,9 @@
 
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif.h"
+#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5
 #include "esp_netif_net_stack.h"
-
+#endif
 #if ESP_IDF_VERSION_MAJOR > 4 && defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_ESP_NETIF_BRIDGE_EN)
 #include "esp_netif_br_glue.h"
 #endif
@@ -217,7 +218,9 @@
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
+#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5
 #include "lwip/esp_netif_net_stack.h"
+#endif
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
 #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -98,9 +98,9 @@
 #include "esp_event.h"
 #endif
 
+#include "esp_netif_net_stack.h"
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif.h"
-#include "esp_netif_net_stack.h"
 
 #if ESP_IDF_VERSION_MAJOR > 4 && defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_ESP_NETIF_BRIDGE_EN)
 #include "esp_netif_br_glue.h"
@@ -212,12 +212,12 @@
 #endif
 #endif
 
+#include "lwip/esp_netif_net_stack.h"
 #ifdef ESP_IDF_COMP_LWIP_ENABLED
 #include "lwip/dns.h"
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
-#include "lwip/esp_netif_net_stack.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
 #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -100,7 +100,7 @@
 
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif.h"
-#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5
+#if ESP_IDF_VERSION_MAJOR > 4
 #include "esp_netif_net_stack.h"
 #endif
 #if ESP_IDF_VERSION_MAJOR > 4 && defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_ESP_NETIF_BRIDGE_EN)
@@ -218,7 +218,7 @@
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
-#if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5
+#if ESP_IDF_VERSION_MAJOR > 4
 #include "lwip/esp_netif_net_stack.h"
 #endif
 #include "esp_sntp.h"

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -100,6 +100,8 @@
 
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif.h"
+#include "esp_netif_net_stack.h"
+
 #if ESP_IDF_VERSION_MAJOR > 4 && defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_ESP_NETIF_BRIDGE_EN)
 #include "esp_netif_br_glue.h"
 #endif
@@ -215,6 +217,7 @@
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
+#include "lwip/esp_netif_net_stack.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
 #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -98,9 +98,9 @@
 #include "esp_event.h"
 #endif
 
-#include "esp_netif_net_stack.h"
 #ifdef ESP_IDF_COMP_ESP_NETIF_ENABLED
 #include "esp_netif.h"
+#include "esp_netif_net_stack.h"
 
 #if ESP_IDF_VERSION_MAJOR > 4 && defined(CONFIG_ESP_NETIF_TCPIP_LWIP) && defined(CONFIG_ESP_NETIF_BRIDGE_EN)
 #include "esp_netif_br_glue.h"
@@ -212,12 +212,12 @@
 #endif
 #endif
 
-#include "lwip/esp_netif_net_stack.h"
 #ifdef ESP_IDF_COMP_LWIP_ENABLED
 #include "lwip/dns.h"
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
+#include "lwip/esp_netif_net_stack.h"
 #include "esp_sntp.h"
 #include "ping/ping_sock.h"
 #if ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
See https://github.com/esp-rs/esp-idf-svc/issues/537 for more details. The goal is to be able to access the underlying `netif` struct from an `esp_netif_t`. 

#### Testing
Works. The necessary function is exposed properly:
```rust
use esp_idf_svc::sys::esp_netif_get_netif_impl
```