### PR TITLE
Introduce esp_idf_version_patch_at_least_X_Y_Z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
         idf-version:
-          - v4.4.8
-          - v5.0.9
+#          - v4.4.8
+#          - v5.0.9
           - v5.1.6
           - v5.2.5
           - v5.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     due to significant changes in the ESP-IDF driver code layout since ESP-IDF 5.3.x
 
 ### Added
-- `esp_idf_version_at_least_X_Y_Z` `cfg` constants for easier conditional compilation against various ESP-IDF versions
+- `esp_idf_version_at_least_X_Y_Z` and `esp_idf_version_patch_at_least_X_Y_Z` `cfg` constants for easier conditional compilation against various ESP-IDF versions
 - Compatibility with ESP-IDF v5.4.X, v5.5.x
 
 ### Fixed

--- a/build/common.rs
+++ b/build/common.rs
@@ -190,7 +190,8 @@ impl EspIdfVersion {
         Ok(value)
     }
 
-    /// Return an iterator of strings, where each string is of the form `esp_idf_version_at_least_X_Y_Z`.
+    /// Return an iterator of strings, where each string is either of the form `esp_idf_version_at_least_X_Y_Z`
+    /// or of the form `esp_idf_version_patch_at_least_X_Y_Z`.
     ///
     /// X.Y.Z denotes a released ESP-IDF version which is smaller or equal to the ESP-IDF
     /// verson against which we are compiling.
@@ -199,6 +200,9 @@ impl EspIdfVersion {
     /// - `esp_idf_version_at_least_4_4_0` .. `esp_idf_version_at_least_4_4_10`
     /// - `esp_idf_version_at_least_5_0_0` .. `esp_idf_version_at_least_5_0_10`
     /// - ... and so on, up to `esp_idf_version_at_least_5_2_1`
+    ///
+    /// Additionally, for e.g. ESP-IDF 5.2.1, the iterator will yield:
+    /// - `esp_idf_version_patch_at_least_5_2_0` .. `esp_idf_version_patch_at_least_5_2_1`
     ///
     /// This is useful for generating conditional compilation flags for version-specific ESP-IDF features
     /// which is otherwise very difficut because the Rust `cfg` syntax does not support
@@ -216,16 +220,29 @@ impl EspIdfVersion {
         // This can be increased should an ESP-IDF version with a patch level > 10 ever appears (very unlikely)
         const MAX_PATCH_LEVEL: u8 = 10;
 
-        VER_RANGES
-            .into_iter()
-            .flat_map(|(maj, min_min, min_max)| (min_min..=min_max).map(move |min| (maj, min)))
-            .flat_map(|(maj, min)| (0..=MAX_PATCH_LEVEL).map(move |patch| (maj, min, patch)))
+        let versions = || {
+            VER_RANGES
+                .into_iter()
+                .flat_map(|(maj, min_min, min_max)| (min_min..=min_max).map(move |min| (maj, min)))
+                .flat_map(|(maj, min)| (0..=MAX_PATCH_LEVEL).map(move |patch| (maj, min, patch)))
+        };
+
+        versions()
             .filter(move |(maj, min, patch)| {
                 cur_maj > *maj
                     || (cur_maj == *maj && cur_min > *min)
                     || (cur_maj == *maj && cur_min == *min && cur_patch >= *patch)
             })
             .map(|(maj, min, patch)| format!("esp_idf_version_at_least_{maj}_{min}_{patch}"))
+            .chain(
+                versions()
+                    .filter(move |(maj, min, patch)| {
+                        cur_maj == *maj && cur_min == *min && cur_patch >= *patch
+                    })
+                    .map(|(maj, min, patch)| {
+                        format!("esp_idf_version_patch_at_least_{maj}_{min}_{patch}")
+                    }),
+            )
     }
 }
 

--- a/src/app_desc.rs
+++ b/src/app_desc.rs
@@ -79,9 +79,17 @@ macro_rules! esp_app_desc {
                     $crate::ESP_IDF_VERSION_PATCH
                 )),
                 app_elf_sha256: [0; 32],
-                #[cfg(all(esp_idf_version_at_least_5_2_3, not(esp_idf_version_full = "5.3.0"), not(esp_idf_version_full = "5.3.1")))]
+                #[cfg(any(
+                    esp_idf_version_patch_at_least_5_1_7,
+                    esp_idf_version_patch_at_least_5_2_3,
+                    esp_idf_version_at_least_5_3_2,
+                ))]
                 min_efuse_blk_rev_full: $crate::CONFIG_ESP_EFUSE_BLOCK_REV_MIN_FULL as _,
-                #[cfg(all(esp_idf_version_at_least_5_2_3, not(esp_idf_version_full = "5.3.0"), not(esp_idf_version_full = "5.3.1")))]
+                #[cfg(any(
+                    esp_idf_version_patch_at_least_5_1_7,
+                    esp_idf_version_patch_at_least_5_2_3,
+                    esp_idf_version_at_least_5_3_2,
+                ))]
                 max_efuse_blk_rev_full: $crate::CONFIG_ESP_EFUSE_BLOCK_REV_MAX_FULL as _,
                 #[cfg(esp_idf_version_at_least_5_4_0)]
                 mmu_page_size: 0,
@@ -89,9 +97,17 @@ macro_rules! esp_app_desc {
                 reserv3: [0; 3],
                 #[cfg(esp_idf_version_at_least_5_4_0)]
                 reserv2: [0; 18],
-                #[cfg(all(esp_idf_version_at_least_5_2_3, not(esp_idf_version_at_least_5_4_0), not(esp_idf_version_full = "5.3.0"), not(esp_idf_version_full = "5.3.1")))]
+                #[cfg(any(
+                    esp_idf_version_patch_at_least_5_1_7,
+                    esp_idf_version_patch_at_least_5_2_3,
+                    esp_idf_version_patch_at_least_5_3_2,
+                ))]
                 reserv2: [0; 19],
-                #[cfg(any(not(esp_idf_version_at_least_5_2_3), esp_idf_version_full = "5.3.0", esp_idf_version_full = "5.3.1"))]
+                #[cfg(not(any(
+                    esp_idf_version_patch_at_least_5_1_7,
+                    esp_idf_version_patch_at_least_5_2_3,
+                    esp_idf_version_at_least_5_3_2,
+                )))]
                 reserv2: [0; 20],
             }
         };


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Using `esp_idf_version_at_least` is nice but still not ideal.
Sometimes, when the Espressif folks back-port stuff into patch releases, we have the annoying case (e.g. esp_app_desc, but not only), where we have to do the following version checks:
version >= 5.1.7 && version < 5.2
or version >= 5.2.3 && version < 5.3
or version >= 5.3.2

while the above can be expressed with:
```rust
#[cfg(any(
    all(esp_idf_version_at_least_5_1_7, not(esp_idf_version_at_least_5_2_0)),
    all(esp_idf_version_at_least_5_2_3, not(esp_idf_version_at_least_5_3_0)),
    esp_idf_version_at_least_5_3_2
))]
```

The `*_patch_` variants allow us to shorten the above to just:
```rust
#[cfg(any(
    esp_idf_version_patch_at_least_5_1_7,
    esp_idf_version_patch_at_least_5_2_3,
    esp_idf_version_at_least_5_3_2
))]
```

Given how little overhead the `patch` variants add (i.e. if the used ESP-IDF is 5.1.6, it will add just 6 extra confs), I think it is worth it given the readability and the less chance for typing errors.

#### Testing

With the esp_app_desc macro.