### PR TITLE
esp_wifi_remote/esp_hosted bindings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add raw bindings for `esp_lcd_mipi_dsi.h` and `esp_ldo_regulator.h` (#398)
 - Pulse counter bindings for esp32p4
 - `impl core::error::Error for EspError`
+- Added bindings for esp_wifi_remote and esp_hosted
 
 ### Fixed
 - Fix the `esp_app_desc!` macro so the reserv3 field is correct for ESP IDF v5.4

--- a/resources/cmake_project/CMakeLists.txt
+++ b/resources/cmake_project/CMakeLists.txt
@@ -9,6 +9,14 @@ set(SDKCONFIG_DEFAULTS $ENV{SDKCONFIG_DEFAULTS})
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+# Set ESP_IDF_VERSION env var for components that need it (e.g. esp_wifi_remote Kconfig).
+# ESP-IDF's version.cmake only sets IDF_VERSION, not ESP_IDF_VERSION.
+# Use major.minor format to match component Kconfig filenames (e.g. Kconfig.idf_v5.3.in).
+# Looks like this is set in idf_tools.py in esp-idf, but since we're not using esp-idf's,
+# build system directly, and some components expect this env var to be set, we need to set it here. See
+# https://github.com/espressif/esp-wifi-remote/issues/85
+set(ENV{ESP_IDF_VERSION} "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}")
+
 set(dependencies_lock "${CMAKE_CURRENT_LIST_DIR}/dependencies.lock")
 set(components_lock "$ENV{PROJECT_DIR}/components_${IDF_TARGET}.lock")
 

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -136,6 +136,14 @@
 #endif
 #endif
 
+#ifdef ESP_IDF_COMP_ESP_WIFI_REMOTE_ENABLED
+#include "esp_wifi_remote.h"
+#endif
+
+#ifdef ESP_IDF_COMP_ESP_HOSTED_ENABLED
+#include "esp_hosted.h"
+#endif
+
 #if defined(ESP_IDF_COMP_ESP_COEX_ENABLED) && (ESP_IDF_VERSION_MAJOR > 5 || ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 1)
 #include "esp_coexist.h"
 #ifdef CONFIG_SOC_IEEE802154_SUPPORTED


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Both the esp_wifi_remote and esp_hosted bindings have been added, along with a fix for a missing ESP_IDF_VERSION set that comes from the get_idf_version function in idf_tools.py, which is called by idf.py during build. Since we're not using idf.py directly, we're missing this environment variable and setting it here fixes this gap for modules that use it.

#### Testing

With some changes to esp-idf-svc, was able to successfully connect to a 2.4 GHz wifi network using a test app:

```
I (3589) RPC_WRAP: Coprocessor Boot-up
E (3740) system_api: 0 mac type is incorrect (not found)
E (3741) system_api: 1 mac type is incorrect (not found)
W (3766) rpc_utils: Event: SSID XXXXX
I (3785) osc_pedal: Starting WiFi...
I (3892) RPC_WRAP: ESP Event: wifi station started
I (3912) RPC_WRAP: ESP Event: wifi station started
I (4028) osc_pedal: WiFi started. Connecting...
I (4028) H_API: esp_wifi_remote_connect
I (6923) RPC_WRAP: ESP Event: Station mode: Connected
I (6923) esp_wifi_remote: esp_wifi_internal_reg_rxcb: sta: 0x40077b54
I (6940) osc_pedal: WiFi connected. Waiting for network interface...
I (8348) esp_netif_handlers: sta ip: 192.168.1.130, mask: 255.255.0.0, gw: 192.168.1.1
I (8376) osc_pedal: WiFi connected! IP: 192.168.1.130
I (8376) osc_pedal: WiFi test passed!
```

Related to:
- https://github.com/esp-rs/esp-idf-svc/pull/640
- https://github.com/esp-rs/esp-idf-hal/pull/572