### PR TITLE
picolibc: add check for `--cfg espidf_picolibc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
         run: cargo clippy --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -- -Dwarnings -Adeprecated
 
       - name: Build | Compile (Native)
@@ -92,7 +92,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
         run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Build | Compile (Native), no_std
@@ -100,7 +100,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
         run: cargo build --target ${{ matrix.target }} --no-default-features -Zbuild-std=std,panic_abort
 
 #      - name: Build | Compile (Native), alloc
@@ -108,7 +108,7 @@ jobs:
 #        env:
 #          ESP_IDF_VERSION: ${{ matrix.idf-version }}
 #          ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-#          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v5') && '--cfg espidf_time64' }}"
+#          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
 #        run: cargo build --no-default-features --features alloc --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
 
       - name: Setup | ldproxy
@@ -123,7 +123,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
         run: cargo clippy --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -- -Dwarnings -Adeprecated
 
       - name: Build | Examples
@@ -131,5 +131,5 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
-          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || '--cfg espidf_time64' }}"
+          RUSTFLAGS: "${{ startsWith(matrix.idf-version, 'v4') && '--cfg espidf_time32' || startsWith(matrix.idf-version, 'v6') && '--cfg espidf_time64 --cfg espidf_picolibc' || '--cfg espidf_time64' }}"
         run: cargo build --examples --target ${{ matrix.target }} -Zbuild-std=std,panic_abort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 - Added build-time check for symbol compatibility between `libc` and symbols defined in this library. If you see `libc/esp-idf-sys * mismatch` errors at build time, you might need to update your pinned `libc` version.
+- Related to the above compatibility check, if picolibc is selected (default for esp-idf >= 6.0, instead of newlib), you _must_ set `--cfg espidf_picolibc` in your `.cargo/config.toml` file, so that `libc` is built with the correct definitions:
+```
+[build]
+rustflags = "--cfg espidf_picolibc"
+```
 
 ## [0.37.2] - 2026-03-10
 

--- a/src/checks/libc.rs
+++ b/src/checks/libc.rs
@@ -301,14 +301,8 @@ check_constants!(F_DUPFD_CLOEXEC);
 check_constants!(O_RDONLY);
 check_constants!(O_WRONLY);
 check_constants!(O_RDWR);
-// TODO: picolibc incompatibility, see https://github.com/esp-rs/esp-idf-sys/issues/410
-#[cfg(not(esp_idf_libc_picolibc))]
 check_constants!(O_APPEND);
-// TODO: picolibc incompatibility, see https://github.com/esp-rs/esp-idf-sys/issues/410
-#[cfg(not(esp_idf_libc_picolibc))]
 check_constants!(O_CREAT);
-// TODO: picolibc incompatibility, see https://github.com/esp-rs/esp-idf-sys/issues/410
-#[cfg(not(esp_idf_libc_picolibc))]
 check_constants!(O_TRUNC);
 check_constants!(O_EXCL);
 check_constants!(O_SYNC);
@@ -514,16 +508,14 @@ check_constants!(SIG_IGN);
 check_constants!(SIG_ERR);
 */
 check_constants!(DT_UNKNOWN);
-/* TODO: Fixed upstream https://github.com/rust-lang/libc/pull/5034, uncomment after libc release
 #[cfg(esp_idf_libc_picolibc)]
 check_constants!(DT_FIFO);
 #[cfg(esp_idf_libc_picolibc)]
 check_constants!(DT_CHR);
-check_constants!(DT_DIR); */
+check_constants!(DT_DIR);
 #[cfg(esp_idf_libc_picolibc)]
 check_constants!(DT_BLK);
-/* TODO: Fixed upstream https://github.com/rust-lang/libc/pull/5034, uncomment after libc release
-check_constants!(DT_REG); */
+check_constants!(DT_REG);
 #[cfg(esp_idf_libc_picolibc)]
 check_constants!(DT_LNK);
 #[cfg(esp_idf_libc_picolibc)]

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -16,6 +16,39 @@ const ESP_IDF_TIME64_CHECK: ::std::os::espidf::raw::time_t = 0 as crate::time_t;
 #[allow(unused)]
 const ESP_IDF_TIME64_CHECK_LIBC: ::libc::time_t = 0 as crate::time_t;
 
+/// If any of the two compile_error! items below trigger, you have not properly setup the rustc cfg flag `espidf_picolibc`:
+/// When compiling against ESP-IDF V6.X or later (which uses picolibc by default), you need to define the following
+/// in your `.cargo/config.toml` file (look for this file in the root of your binary crate):
+/// ```
+/// [build]
+/// rustflags = "--cfg espidf_picolibc"
+/// ```
+///
+/// When compiling against ESP-IDF V5.X or earlier (which uses newlib), you need to remove the above flag
+#[cfg(all(espidf_picolibc, not(esp_idf_libc_picolibc)))]
+compile_error!(
+    "espidf_picolibc is set but ESP-IDF is not configured to use picolibc. Remove --cfg espidf_picolibc from your rustflags."
+);
+#[cfg(all(esp_idf_libc_picolibc, not(espidf_picolibc)))]
+compile_error!(
+    "ESP-IDF is configured to use picolibc but espidf_picolibc is not set. Add --cfg espidf_picolibc to your rustflags in .cargo/config.toml."
+);
+/// Verify that libc::O_APPEND matches the expected value for the configured C library.
+/// If this does not compile, espidf_picolibc is set incorrectly in your rustflags.
+#[allow(unused)]
+const ESP_IDF_PICOLIBC_CHECK: () = {
+    #[cfg(espidf_picolibc)]
+    assert!(
+        ::libc::O_APPEND == 1024,
+        "libc::O_APPEND mismatch: espidf_picolibc is set but libc was not compiled with it"
+    );
+    #[cfg(not(espidf_picolibc))]
+    assert!(
+        ::libc::O_APPEND == 8,
+        "libc::O_APPEND mismatch: espidf_picolibc is not set but libc was compiled with it"
+    );
+};
+
 // Check for libc/esp-idf-sys type and constant mismatches.
 #[cfg(feature = "std")]
 mod libc;


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable). => N/A
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Makes sure that `--cfg espidf_picolibc` is set if picolibc is selected, and update CI.

Question: Do we want to test newlib config on esp-idf 6.0+? We could add to the CI matrix if we wanted to.

~~Not quite merge-able as-is, the third HACK commit will need to be removed when the next `libc` 0.2 is released (looks reasonably frequent so we could just wait I guess).~~

#### Testing
Local, then CI.