### PR TITLE
Using with custom `partition.csv` file (doc only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ For more information, check out:
 ## Known limitations
 
 * ESP IDF can’t be compiled on filesystems without support for symbolic links (e.g. FAT)
+* projects that use a custom `partitions.csv`:
+
+	- do not define `CONFIG_PARTITION_TABLE_CUSTOM=y`, `CONFIG_PARTITION_TABLE_[CUSTOM_]FILENAME` in your `sdkconfig.defaults`. The build would not use your custom partitions - nor does it need to.
+	- for flashing use `espflash flash [...] --partition-table partitions.csv`


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [na] I have updated existing examples or added new ones (if applicable).
- [na] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [na] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [-] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Since the repo has no mention to `CONFIG_PARTITION_TABLE_CUSTOM_FILENAME` or `CONFIG_PARTITION_TABLE_FILENAME`, it may be surprising to the user that setting these `sdkconfig.defaults` keys breaks the build.

This is discussed at #395 . With that help, I got my project to head further, and decided to make a short doc-only suggestion to the repo, so others would know, as well. 

#### Testing

The suggested work-around "works for me".