### PR TITLE
Include gpio_sig_map.h on ESP-IDF 6 for SIG_GPIO_OUT_IDX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 - Added build-time check for symbol compatibility between `libc` and symbols defined in this library. If you see `libc/esp-idf-sys * mismatch` errors at build time, you might need to update your pinned `libc` version.
 
+### Fixed
+- Include `soc/gpio_sig_map.h` on ESP-IDF 6 so `SIG_GPIO_OUT_IDX` is available in the bindings
+
 ## [0.37.2] - 2026-03-10
 
 ### Fixed

--- a/src/include/esp-idf/bindings.h
+++ b/src/include/esp-idf/bindings.h
@@ -453,10 +453,12 @@
 // GPIO
 #if OLD_DRIVER_COMP || defined(ESP_IDF_COMP_ESP_DRIVER_GPIO_ENABLED)
 #include "driver/gpio.h"
-// In ESP-IDF v6.0, soc/gpio_periph.h no longer includes soc/gpio_reg.h, so GPIO_OUT_REG
-// and friends are no longer transitively visible. Include it explicitly.
+// In ESP-IDF v6.0, soc/gpio_periph.h no longer includes soc/gpio_reg.h or
+// soc/gpio_sig_map.h, so GPIO_OUT_REG / SIG_GPIO_OUT_IDX and friends are no
+// longer transitively visible. Include them explicitly.
 #if ESP_IDF_VERSION_MAJOR >= 6
 #include "soc/gpio_reg.h"
+#include "soc/gpio_sig_map.h"
 #endif
 #endif
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
On ESP-IDF v6.0, `soc/gpio_periph.h` no longer transitively includes `soc/gpio_sig_map.h`, so `SIG_GPIO_OUT_IDX` (and related signal-map constants) are missing from the generated Rust bindings. That constant is needed for GPIO matrix bit-bang reconnect.

This change includes `soc/gpio_sig_map.h` under the existing `ESP_IDF_VERSION_MAJOR >= 6` guard in `src/include/esp-idf/bindings.h`, next to the already-required `soc/gpio_reg.h` include, so those symbols are exposed again for ESP-IDF 6+ without affecting older IDF versions.

#### Testing
- Built an ESP32-S3 firmware project that patches this crate and targets ESP-IDF v6.0.2 (`cargo build` for `xtensa-esp32s3-espidf`).
- That project uses `SIG_GPIO_OUT_IDX` with `esp_rom_gpio_connect_out_signal` for GPIO matrix bit-bang reconnect; the build completed successfully.
- Confirmed the generated bindings include `pub const SIG_GPIO_OUT_IDX: u32 = 256`.
