### PR TITLE
Blocklist TinyUSB's telephone CDC descriptor struct to fix E0588 when CONFIG_TINYUSB_CDC_ENABLED=y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Include `soc/gpio_sig_map.h` on ESP-IDF 6 so `SIG_GPIO_OUT_IDX` is available in the bindings
+- Fix E0588 compile error in the generated bindings when the TinyUSB CDC class is enabled (`CONFIG_TINYUSB_CDC_ENABLED=y`) by blocklisting TinyUSB's unused `cdc_desc_func_telephone_call_state_reporting_capabilities_t` descriptor
 
 ## [0.37.2] - 2026-03-10
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -162,7 +162,8 @@ fn main() -> anyhow::Result<()> {
             .blocklist_function("v.*scanf")
             .blocklist_function("_v.*printf_r")
             .blocklist_function("_v.*scanf_r")
-            .blocklist_function("esp_log_writev");
+            .blocklist_function("esp_log_writev")
+            .blocklist_type("cdc_desc_func_telephone_call_state_reporting_capabilities_t");
         // In ESP-IDF < v6.0, pcnt_unit_t exists as both a struct and an enum; blocklist the
         // type so we can provide the enum definition manually in src/pcnt.rs. In v6.0+ the
         // legacy enum is gone, so bindgen can handle the struct fine on its own.


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-sys/blob/main/esp-idf-sys/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Using the `espressif/esp_tinyusb` remote component with `CONFIG_TINYUSB_CDC_ENABLED=y` fails to build:

```
error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
  pub struct cdc_desc_func_telephone_call_state_reporting_capabilities_t
```

TinyUSB's `cdc.h` declares this descriptor as a packed struct containing `uint32_t` bitfields; bindgen emits `#[repr(align(4))]` inside `#[repr(packed)]`, which rustc rejects. The struct is identical in every TinyUSB version, and it only enters the bindings when CDC is enabled, which is why #359 (MSC only) worked and CI (no TinyUSB options) doesn't catch it.

Fix: blocklist the type. It's an unused telephone-modem descriptor, referenced nowhere in TinyUSB or esp_tinyusb.

#### Testing
Verified on an ESP32-P4 / ESP-IDF v5.5.3 project using CDC-ACM: fails with the error above on current master, builds cleanly with this change.